### PR TITLE
Add step outputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,85 @@ jobs:
           version: '0.10.0'
       - name: Verify CLI exists
         run: esc version
+  test-individual-keys:
+    strategy: {matrix: {os: [ubuntu-latest]}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Install ESC and open an environment
+        id: esc
+        uses: ./
+        with:
+          environment: 'pulumi/github/esc-action'
+          keys: 'FOO,SOME_IMPORTANT_KEY'
+          cloud-url: https://api.pulumi-staging.io
+          export-environment-variables: false
+      - name: Verify injection
+        run: |
+          echo "Testing env injection..."
+          REQUIRED_VARS=("K1" "K2")
+          for var in "${REQUIRED_VARS[@]}"; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set to: ${!var}"
+          done
+          if [[ -n $(env | grep "^\(FOO\|SOME_IMPORTANT_KEY\|TEST_ENV\)=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
+        env:
+          K1: ${{ steps.esc.outputs.FOO }}
+          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
+  test-all-keys:
+    strategy: {matrix: {os: [ubuntu-latest]}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Install ESC and open an environment
+        id: esc
+        uses: ./
+        with:
+          # This action uses the https://app.pulumi-staging.io/pulumi/esc/github/esc-action environment
+          environment: 'pulumi/github/esc-action'
+          cloud-url: https://api.pulumi-staging.io
+          export-environment-variables: false
+      - name: Verify injection
+        run: |
+          echo "Testing env injection..."
+          REQUIRED_VARS=("K1" "K2" "K3")
+          for var in "${REQUIRED_VARS[@]}"; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set to: ${!var}"
+          done
+          if [[ -n $(env | grep "^\(FOO\|SOME_IMPORTANT_KEY\|TEST_ENV\)=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
+        env:
+          K1: ${{ steps.esc.outputs.FOO }}
+          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
+          K3: ${{ steps.esc.outputs.TEST_ENV }}
   test-individual-key-injection:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}
@@ -40,6 +119,7 @@ jobs:
           requested-token-type: urn:pulumi:token-type:access_token:organization
           cloud-url: https://api.pulumi-staging.io
       - name: Inject only specific environment variables
+        id: esc
         uses: ./
         with:
           environment: 'pulumi/github/esc-action'
@@ -56,6 +136,11 @@ jobs:
             fi
             echo "$var is set to: ${!var}"
           done
+          if [[ -n $(env | grep "^TEST_ENV=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
   test-all-key-injection:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'The URL of the Pulumi Cloud API. Defaults to https://api.pulumi.com.'
     required: false
     default: 'https://api.pulumi.com'
+  export-environment-variables:
+    description: "Whether or not to export environment variables. All environment variables will always be available in the 'env' step output."
+    required: false
+    default: true
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as tc from '@actions/tool-cache';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { env } from 'process';
 
 async function getInstalledVersion(): Promise<string | undefined> {
     const installed = await io.which('esc');
@@ -67,6 +68,7 @@ async function run(): Promise<void> {
         const environment: string = core.getInput('environment');
         const keys: string = core.getInput('keys');
         const cloudUrl: string = core.getInput('cloud-url');
+        const exportVars = core.getInput('export-environment-variables') === "" ? true : core.getBooleanInput('export-environment-variables');
 
         /*
           Install ESC CLI (either the latest or a specific version)
@@ -89,7 +91,7 @@ async function run(): Promise<void> {
         // Check if an environment was provided. If not, skip injection.
         if (environment) {
             // Open the environment.
-            core.startGroup(`Injecting environment variables from ESC environment: ${environment}`);
+            core.startGroup(`Opening ESC environment: ${environment}`);
             const result = await exec.getExecOutput(
                 'esc',
                 ['open', environment, '--format', 'dotenv'],
@@ -102,7 +104,7 @@ ${result.stderr}`)
             }
 
             // Parse the output
-            let envObj: Record<string, string> = {};
+            let dotenv: Record<string, string> = {};
             try {
                 // The output is in the format KEY="VALUE"
                 // We need to convert it to an object
@@ -111,39 +113,35 @@ ${result.stderr}`)
                     const [key, value] = line.split('=');
                     if (key && value) {
                         // Remove quotes from the value
-                        envObj[key.trim()] = value.replace(/(^"|"$)/g, '').trim();
+                        dotenv[key.trim()] = value.replace(/(^"|"$)/g, '').trim();
                     }
                 }
             } catch (parseErr) {
                 throw new Error(`Failed to open environment: ${parseErr}`);
             }
 
-            const envFilePath = process.env.GITHUB_ENV;
-            if (!envFilePath) {
-                throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
-            }
-
-            // If user wants to inject specific variables:
-            if (keys) {
-                const variables = keys.split(',').map(v => v.trim());
-                for (const variable of variables) {
-                    const value = envObj[variable];
-
-                    if (value) {
-                        core.setSecret(value);
-                        fs.appendFileSync(envFilePath, `${variable}<<EOF\n${value}\nEOF\n`);
-                        core.info(`Injected ${variable}`);
-                    } else {
-                        core.warning(`No value found for environmentVariables.${variable}`);
-                    }
-                }
-            } else {
-                // If no specific keys are provided, inject all environment variables
-                // For each key/value, mask and write multiline-friendly format
-                for (const [key, value] of Object.entries(envObj)) {
+            const envVars: Record<string, string> = {};
+            const variables = keys ? keys.split(',').map(v => v.trim()) : Object.keys(dotenv);
+            for (const key of variables) {
+                const value = dotenv[key];
+                if (value) {
                     // Mask the secret so it doesn't appear in logs
                     core.setSecret(value);
 
+                    envVars[key] = value;
+                    core.setOutput(key, value);
+                } else {
+                    core.warning(`No value found for environmentVariables.${key}`);
+                }
+            }
+
+            if (exportVars) {
+                const envFilePath = process.env.GITHUB_ENV;
+                if (!envFilePath) {
+                    throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
+                }
+
+                for (const [key, value] of Object.entries(envVars)) {
                     // Append in multiline syntax to handle any newlines safely
                     // e.g.: MY_ENV_VAR<<EOF
                     // line1
@@ -151,9 +149,9 @@ ${result.stderr}`)
                     // EOF
                     fs.appendFileSync(envFilePath, `${key}<<EOF\n${value}\nEOF\n`);
                 }
-                // Signal success
-                core.info(`Injected ${Object.keys(envObj).length} environment variables`);
+                core.info(`Injected ${Object.keys(envVars).length} environment variables`);
             }
+
             core.endGroup();
         }
     } catch (error) {


### PR DESCRIPTION
And allow users to avoid exporting environment variables. This allows
users to precisely control which environment variables are passed to
successive steps (analagous to the use of `secrets` with `env`).