### PR TITLE
Support key remapping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,45 +66,6 @@ jobs:
         env:
           K1: ${{ steps.esc.outputs.FOO }}
           K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
-  test-remap-individual-keys:
-    strategy: {matrix: {os: [ubuntu-latest]}}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      - name: Authenticate with Pulumi Cloud
-        uses: pulumi/auth-actions@v1
-        with:
-          organization: pulumi
-          requested-token-type: urn:pulumi:token-type:access_token:organization
-          cloud-url: https://api.pulumi-staging.io
-      - name: Install ESC and open an environment
-        id: esc
-        uses: ./
-        with:
-          environment: 'pulumi/github/esc-action'
-          keys: 'BAR=FOO,SOME_IMPORTANT_KEY'
-          cloud-url: https://api.pulumi-staging.io
-          export-environment-variables: false
-      - name: Verify injection
-        run: |
-          echo "Testing env injection..."
-          REQUIRED_VARS=("K1" "K2")
-          for var in "${REQUIRED_VARS[@]}"; do
-            if [[ -z "${!var}" ]]; then
-              echo "Error: $var is not set or empty" >&2
-              exit 1
-            fi
-            echo "$var is set to: ${!var}"
-          done
-          if [[ -n $(env | grep "^\(FOO\|BAR\|SOME_IMPORTANT_KEY\|TEST_ENV\)=") ]]; then
-            echo "Error: unexpected variables are set" >&2
-            env
-            exit 1
-          fi
-        env:
-          K1: ${{ steps.esc.outputs.BAR }}
-          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
   test-all-keys:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}
@@ -143,47 +104,6 @@ jobs:
           fi
         env:
           K1: ${{ steps.esc.outputs.FOO }}
-          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
-          K3: ${{ steps.esc.outputs.TEST_ENV }}
-  test-remap-all-keys:
-    strategy: {matrix: {os: [ubuntu-latest]}}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      - name: Authenticate with Pulumi Cloud
-        uses: pulumi/auth-actions@v1
-        with:
-          organization: pulumi
-          requested-token-type: urn:pulumi:token-type:access_token:organization
-          cloud-url: https://api.pulumi-staging.io
-      - name: Install ESC and open an environment
-        id: esc
-        uses: ./
-        with:
-          # This action uses the https://app.pulumi-staging.io/pulumi/esc/github/esc-action environment
-          environment: 'pulumi/github/esc-action'
-          keys: 'BAR=FOO,*'
-          cloud-url: https://api.pulumi-staging.io
-          export-environment-variables: false
-      - name: Verify injection
-        run: |
-          echo "Testing env injection..."
-          REQUIRED_VARS=("K1" "K2" "K3")
-          for var in "${REQUIRED_VARS[@]}"; do
-            if [[ -z "${!var}" ]]; then
-              echo "Error: $var is not set or empty" >&2
-              exit 1
-            fi
-            echo "$var is set to: ${!var}"
-          done
-          if [[ -n $(env | grep "^\(FOO\|BAR\|SOME_IMPORTANT_KEY\|TEST_ENV\)=") ]]; then
-            echo "Error: unexpected variables are set" >&2
-            env
-            exit 1
-          fi
-        env:
-          K1: ${{ steps.esc.outputs.BAR }}
           K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
           K3: ${{ steps.esc.outputs.TEST_ENV }}
   test-individual-key-injection:
@@ -238,7 +158,7 @@ jobs:
         uses: ./
         with:
           environment: 'pulumi/github/esc-action'
-          keys: 'BAR=FOO,SOME_IMPORTANT_KEY'
+          export-environment-variables: 'BAR=FOO,SOME_IMPORTANT_KEY'
           cloud-url: https://api.pulumi-staging.io
       - name: Verify injection
         run: |
@@ -336,7 +256,7 @@ jobs:
         with:
           # This action uses the https://app.pulumi-staging.io/pulumi/esc/github/esc-action environment
           environment: 'pulumi/github/esc-action'
-          keys: BAR=FOO,*
+          export-environment-variables: BAR=FOO,*
           cloud-url: https://api.pulumi-staging.io
       - name: Verify injection
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,45 @@ jobs:
         env:
           K1: ${{ steps.esc.outputs.FOO }}
           K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
+  test-remap-individual-keys:
+    strategy: {matrix: {os: [ubuntu-latest]}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Install ESC and open an environment
+        id: esc
+        uses: ./
+        with:
+          environment: 'pulumi/github/esc-action'
+          keys: 'BAR=FOO,SOME_IMPORTANT_KEY'
+          cloud-url: https://api.pulumi-staging.io
+          export-environment-variables: false
+      - name: Verify injection
+        run: |
+          echo "Testing env injection..."
+          REQUIRED_VARS=("K1" "K2")
+          for var in "${REQUIRED_VARS[@]}"; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set to: ${!var}"
+          done
+          if [[ -n $(env | grep "^\(FOO\|BAR\|SOME_IMPORTANT_KEY\|TEST_ENV\)=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
+        env:
+          K1: ${{ steps.esc.outputs.BAR }}
+          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
   test-all-keys:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}
@@ -106,6 +145,47 @@ jobs:
           K1: ${{ steps.esc.outputs.FOO }}
           K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
           K3: ${{ steps.esc.outputs.TEST_ENV }}
+  test-remap-all-keys:
+    strategy: {matrix: {os: [ubuntu-latest]}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Install ESC and open an environment
+        id: esc
+        uses: ./
+        with:
+          # This action uses the https://app.pulumi-staging.io/pulumi/esc/github/esc-action environment
+          environment: 'pulumi/github/esc-action'
+          keys: 'BAR=FOO,*'
+          cloud-url: https://api.pulumi-staging.io
+          export-environment-variables: false
+      - name: Verify injection
+        run: |
+          echo "Testing env injection..."
+          REQUIRED_VARS=("K1" "K2" "K3")
+          for var in "${REQUIRED_VARS[@]}"; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set to: ${!var}"
+          done
+          if [[ -n $(env | grep "^\(FOO\|BAR\|SOME_IMPORTANT_KEY\|TEST_ENV\)=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
+        env:
+          K1: ${{ steps.esc.outputs.BAR }}
+          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
+          K3: ${{ steps.esc.outputs.TEST_ENV }}
   test-individual-key-injection:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}
@@ -137,6 +217,41 @@ jobs:
             echo "$var is set to: ${!var}"
           done
           if [[ -n $(env | grep "^TEST_ENV=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
+  test-remap-individual-key-injection:
+    strategy: {matrix: {os: [ubuntu-latest]}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Inject only specific environment variables
+        id: esc
+        uses: ./
+        with:
+          environment: 'pulumi/github/esc-action'
+          keys: 'BAR=FOO,SOME_IMPORTANT_KEY'
+          cloud-url: https://api.pulumi-staging.io
+      - name: Verify injection
+        run: |
+          echo "Testing env injection..."
+          REQUIRED_VARS=("BAR" "SOME_IMPORTANT_KEY")
+          for var in "${REQUIRED_VARS[@]}"; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set to: ${!var}"
+          done
+          if [[ -n $(env | grep "^\(TEST_ENV\|FOO\)=") ]]; then
             echo "Error: unexpected variables are set" >&2
             env
             exit 1
@@ -204,6 +319,41 @@ jobs:
             fi
             echo "$var is set to: ${!var}"
           done
+  test-remap-all-key-injection:
+    strategy: {matrix: {os: [ubuntu-latest]}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Install and inject ESC environment variables
+        uses: ./
+        with:
+          # This action uses the https://app.pulumi-staging.io/pulumi/esc/github/esc-action environment
+          environment: 'pulumi/github/esc-action'
+          keys: BAR=FOO,*
+          cloud-url: https://api.pulumi-staging.io
+      - name: Verify injection
+        run: |
+          echo "Testing env injection..."
+          REQUIRED_VARS=("BAR" "SOME_IMPORTANT_KEY" "TEST_ENV")
+          for var in "${REQUIRED_VARS[@]}"; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set to: ${!var}"
+          done
+          if [[ -n $(env | grep "^FOO=") ]]; then
+            echo "Error: unexpected variables are set" >&2
+            env
+            exit 1
+          fi
   test-oidc-config:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -52106,9 +52106,52 @@ function getOidcLoginConfig(cloudUrl) {
         exportEnvironmentVariables: false,
     });
 }
-function getExportEnvironmentVariables() {
-    const exportVars = getBooleanInput('export-environment-variables', 'EXPORT_ENVIRONMENT_VARIABLES');
-    return exportVars === undefined ? true : exportVars;
+function getExportEnvironmentVariables(keys) {
+    const exportAll = !keys;
+    const keysMapping = keys ? Object.fromEntries(keys.split(',').map(k => [k, k])) : {};
+    // If no value is present for keys, default to pulling mappings from keys.
+    const input = getInput('export-environment-variables', 'EXPORT_ENVIRONMENT_VARIABLES');
+    if (!input) {
+        return [keysMapping, exportAll];
+    }
+    // If the value is a boolean true or false, return it with the mappings from keys.
+    try {
+        const exportAny = parseBooleanValue(input);
+        return !exportAny ? [{}, false] : [keysMapping, exportAll];
+    }
+    catch { }
+    // Otherwise, parse the value as a list of [FOO=]BAR key-value pairs, where FOO is the name of the envvar to set and
+    // BAR is the name of the variable to use as the value. If FOO is omitted, BAR is also used as the name of the
+    // envvar to set. If BAR is '*', then all unmapped variables are implicitly mapped to themselves.
+    //
+    // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
+    // this environment:
+    //
+    //   GITHUB_TOKEN=PULUMI_BOT_TOKEN,
+    //   AWS_KEY_ID=AWS_KEY_ID
+    //   AWS_SECRET_KEY=AWS_SECRET_KEY
+    //   AWS_SESSION_TOKEN=AWS_SESSION_TOKEN
+    //
+    // If the source ESC env also contained other environment variables, they would not be exported. All non-mapped variables
+    // can be exported with the identity mapping by including '*' as a key. For example, 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,*`
+    // would also export the environment above assuming no other envvars exist in the ESC environment.
+    let all = false;
+    const mappings = {};
+    for (const mapping of input.split(',').map(v => v.trim())) {
+        if (mapping === '*') {
+            all = true;
+            continue;
+        }
+        const eq = mapping.indexOf('=');
+        if (eq === -1) {
+            mappings[mapping] = mapping;
+        }
+        else {
+            const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)];
+            mappings[from] = to;
+        }
+    }
+    return [mappings, all];
 }
 async function getInstalledVersion() {
     const installed = await ioExports.which('esc');
@@ -52161,7 +52204,7 @@ async function run() {
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
-        const exportVars = getExportEnvironmentVariables();
+        const [mapping, allVars] = getExportEnvironmentVariables(keys);
         const useOidcAuth = getBooleanInput('oidc-auth', 'ESC_ACTION_OIDC_AUTH');
         if (useOidcAuth) {
             const oidcConfig = getOidcLoginConfig(cloudUrl);
@@ -52214,34 +52257,37 @@ ${result.stderr}`);
             catch (parseErr) {
                 throw new Error(`Failed to open environment: ${parseErr}`);
             }
-            const envVars = {};
-            const variables = keys ? keys.split(',').map(v => v.trim()) : Object.keys(dotenv);
-            for (const key of variables) {
-                const value = dotenv[key];
-                if (value) {
-                    // Mask the secret so it doesn't appear in logs
-                    coreExports.setSecret(value);
-                    envVars[key] = value;
-                    coreExports.setOutput(key, value);
-                }
-                else {
-                    coreExports.warning(`No value found for environmentVariables.${key}`);
-                }
+            // Populate step outputs and mark secrets so they do not appear in logs.
+            for (const [key, value] of Object.entries(dotenv)) {
+                coreExports.setSecret(value);
+                coreExports.setOutput(key, value);
             }
-            if (exportVars) {
+            // Calculate the final set of mappings. If allVars is true, add identity mappings for all unmapped variables;
+            // otherwise, just use the user's mappings.
+            const finalMapping = allVars
+                ? Object.assign(Object.fromEntries(Object.keys(dotenv).map(k => [k, k])), mapping)
+                : mapping;
+            // Export envvars.
+            if (Object.keys(finalMapping).length != 0) {
                 const envFilePath = process.env.GITHUB_ENV;
                 if (!envFilePath) {
                     throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
                 }
-                for (const [key, value] of Object.entries(envVars)) {
-                    // Append in multiline syntax to handle any newlines safely
-                    // e.g.: MY_ENV_VAR<<EOF
-                    // line1
-                    // line2
-                    // EOF
-                    require$$1.appendFileSync(envFilePath, `${key}<<EOF\n${value}\nEOF\n`);
+                for (const [from, to] of Object.entries(finalMapping)) {
+                    const value = dotenv[from];
+                    if (value) {
+                        // Append in multiline syntax to handle any newlines safely
+                        // e.g.: MY_ENV_VAR<<EOF
+                        // line1
+                        // line2
+                        // EOF
+                        require$$1.appendFileSync(envFilePath, `${to}<<EOF\n${value}\nEOF\n`);
+                    }
+                    else {
+                        coreExports.warning(`No value found for ${to}=environmentVariables.${from}`);
+                    }
                 }
-                coreExports.info(`Injected ${Object.keys(envVars).length} environment variables`);
+                coreExports.info(`Injected ${Object.keys(finalMapping).length} environment variables`);
             }
             coreExports.endGroup();
         }


### PR DESCRIPTION
If the 'export-environment-variables' input is present and is neither true nor false, interpret it as a list of [FOO=]BAR key-value pairs, where FOO is the name of the envvar to set and BAR is the name of the variable to use as the value. If FOO is omitted, BAR is also used as the name of the envvar to set. If BAR is '*', then all unmapped variables are implicitly mapped to themselves.

For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID, AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export this environment:

    GITHUB_TOKEN=PULUMI_BOT_TOKEN
    AWS_KEY_ID=AWS_KEY_ID
    AWS_SECRET_KEY=AWS_SECRET_KEY
    AWS_SESSION_TOKEN=AWS_SESSION_TOKEN

If the source ESC env also contained other environment variables, they would not be exported. All non-mapped variables can be exported with the identity mapping by including '*' as a key. For example, 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,*` would also export the environment above assuming no other envvars exist in the ESC environment.

Remapping applies to action outputs as well as environment variables.

If `export-environment-variables` is `true`, then `keys` is treated as the source of the mappings to maintain compatibility with existing workflows.