### PR TITLE
Fix OIDC_AUTH envvar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,7 @@ async function run(): Promise<void> {
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
         const [mapping, allVars] = getExportEnvironmentVariables(keys);
 
-        const useOidcAuth = getBooleanInput('oidc-auth', 'ESC_ACTION_OIDC_AUTH');
+        const useOidcAuth = getBooleanInput('oidc-auth', 'OIDC_AUTH');
         if (useOidcAuth) {
             const oidcConfig = getOidcLoginConfig(cloudUrl);
             if (!oidcConfig.success) {


### PR DESCRIPTION
`getInput` automatically adds an `ESC_ACTION_` prefix.