### PR TITLE
Add injection logging

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52127,7 +52127,7 @@ function getExportEnvironmentVariables(keys) {
     // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
     // this environment:
     //
-    //   GITHUB_TOKEN=PULUMI_BOT_TOKEN,
+    //   GITHUB_TOKEN=PULUMI_BOT_TOKEN
     //   AWS_KEY_ID=AWS_KEY_ID
     //   AWS_SECRET_KEY=AWS_SECRET_KEY
     //   AWS_SESSION_TOKEN=AWS_SESSION_TOKEN
@@ -52282,6 +52282,7 @@ ${result.stderr}`);
                         // line2
                         // EOF
                         require$$1.appendFileSync(envFilePath, `${to}<<EOF\n${value}\nEOF\n`);
+                        coreExports.info(`Injected ${to}=${from}`);
                     }
                     else {
                         coreExports.warning(`No value found for ${to}=environmentVariables.${from}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ function getExportEnvironmentVariables(keys: string | undefined): [Record<string
     // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
     // this environment:
     //
-    //   GITHUB_TOKEN=PULUMI_BOT_TOKEN,
+    //   GITHUB_TOKEN=PULUMI_BOT_TOKEN
     //   AWS_KEY_ID=AWS_KEY_ID
     //   AWS_SECRET_KEY=AWS_SECRET_KEY
     //   AWS_SESSION_TOKEN=AWS_SESSION_TOKEN
@@ -271,6 +271,7 @@ ${result.stderr}`)
                         // line2
                         // EOF
                         fs.appendFileSync(envFilePath, `${to}<<EOF\n${value}\nEOF\n`);
+                        core.info(`Injected ${to}=${from}`);
                     } else {
                         core.warning(`No value found for ${to}=environmentVariables.${from}`);
                     }


### PR DESCRIPTION
It appears from https://github.com/pulumi/pulumi-policy-aws/actions/runs/14803858674/job/41722533504
that there may be a bug injecting remapped environment variables. These
changes add some logging to the job to track which environment variables
are mapped.
