### PR TITLE
Fix a bug in multiply-mapped envvars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,12 +158,12 @@ jobs:
         uses: ./
         with:
           environment: 'pulumi/github/esc-action'
-          export-environment-variables: 'BAR=FOO,SOME_IMPORTANT_KEY'
+          export-environment-variables: 'BAR=FOO,BAZ=SOME_IMPORTANT_KEY,SOME_IMPORTANT_KEY'
           cloud-url: https://api.pulumi-staging.io
       - name: Verify injection
         run: |
           echo "Testing env injection..."
-          REQUIRED_VARS=("BAR" "SOME_IMPORTANT_KEY")
+          REQUIRED_VARS=("BAR" "BAZ" "SOME_IMPORTANT_KEY")
           for var in "${REQUIRED_VARS[@]}"; do
             if [[ -z "${!var}" ]]; then
               echo "Error: $var is not set or empty" >&2

--- a/dist/index.js
+++ b/dist/index.js
@@ -52264,16 +52264,19 @@ ${result.stderr}`);
             }
             // Calculate the final set of mappings. If allVars is true, add identity mappings for all unmapped variables;
             // otherwise, just use the user's mappings.
-            const finalMapping = allVars
-                ? Object.assign(Object.fromEntries(Object.keys(dotenv).map(k => [k, k])), mapping)
-                : mapping;
+            if (allVars) {
+                const mapped = new Set(Object.values(mapping));
+                for (const k of Object.keys(dotenv).filter(k => !mapped.has(k))) {
+                    mapping[k] = k;
+                }
+            }
             // Export envvars.
-            if (Object.keys(finalMapping).length != 0) {
+            if (Object.keys(mapping).length != 0) {
                 const envFilePath = process.env.GITHUB_ENV;
                 if (!envFilePath) {
                     throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
                 }
-                for (const [to, from] of Object.entries(finalMapping)) {
+                for (const [to, from] of Object.entries(mapping)) {
                     const value = dotenv[from];
                     if (value) {
                         // Append in multiline syntax to handle any newlines safely
@@ -52288,7 +52291,7 @@ ${result.stderr}`);
                         coreExports.warning(`No value found for ${to}=environmentVariables.${from}`);
                     }
                 }
-                coreExports.info(`Injected ${Object.keys(finalMapping).length} environment variables`);
+                coreExports.info(`Injected ${Object.keys(mapping).length} environment variables`);
             }
             coreExports.endGroup();
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -52148,7 +52148,7 @@ function getExportEnvironmentVariables(keys) {
         }
         else {
             const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)];
-            mappings[from] = to;
+            mappings[to] = from;
         }
     }
     return [mappings, all];
@@ -52273,7 +52273,7 @@ ${result.stderr}`);
                 if (!envFilePath) {
                     throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
                 }
-                for (const [from, to] of Object.entries(finalMapping)) {
+                for (const [to, from] of Object.entries(finalMapping)) {
                     const value = dotenv[from];
                     if (value) {
                         // Append in multiline syntax to handle any newlines safely

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ function getExportEnvironmentVariables(keys: string | undefined): [Record<string
             mappings[mapping] = mapping;
         } else {
             const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)];
-            mappings[from] = to;
+            mappings[to] = from;
         }
     }
     return [mappings, all];
@@ -262,7 +262,7 @@ ${result.stderr}`)
                     throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
                 }
 
-                for (const [from, to] of Object.entries(finalMapping)) {
+                for (const [to, from] of Object.entries(finalMapping)) {
                     const value = dotenv[from];
                     if (value) {
                         // Append in multiline syntax to handle any newlines safely

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,18 +251,21 @@ ${result.stderr}`)
 
             // Calculate the final set of mappings. If allVars is true, add identity mappings for all unmapped variables;
             // otherwise, just use the user's mappings.
-            const finalMapping = allVars
-                ? Object.assign(Object.fromEntries(Object.keys(dotenv).map(k => [k, k])), mapping)
-                : mapping;
+			if (allVars) {
+				const mapped = new Set(Object.values(mapping));
+				for (const k of Object.keys(dotenv).filter(k => !mapped.has(k))) {
+					mapping[k] = k;
+				}
+			}
 
             // Export envvars.
-            if (Object.keys(finalMapping).length != 0) {
+            if (Object.keys(mapping).length != 0) {
                 const envFilePath = process.env.GITHUB_ENV;
                 if (!envFilePath) {
                     throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
                 }
 
-                for (const [to, from] of Object.entries(finalMapping)) {
+                for (const [to, from] of Object.entries(mapping)) {
                     const value = dotenv[from];
                     if (value) {
                         // Append in multiline syntax to handle any newlines safely
@@ -276,7 +279,7 @@ ${result.stderr}`)
                         core.warning(`No value found for ${to}=environmentVariables.${from}`);
                     }
                 }
-                core.info(`Injected ${Object.keys(finalMapping).length} environment variables`);
+                core.info(`Injected ${Object.keys(mapping).length} environment variables`);
             }
 
             core.endGroup();


### PR DESCRIPTION
In the case where a source environment variable was mapped to multiple
destinations, the ESC action would only use the last mapping. These
changes fix the behavior to use all of the listed mappings.
