### PR TITLE
Use repo-specific ESC environment

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/pulumi-esc-action
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true


### PR DESCRIPTION
This repository has repository-specific secrets that need to be migrated to ESC. These changes replace the usage of the common GHA ESC environment with the repository-specific environment.
