### PR TITLE
Don't trim values and use a more unique delimiter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52253,8 +52253,8 @@ ${result.stderr}`);
                     }
                     const [key, value] = [line.slice(0, eq), line.slice(eq + 1)];
                     if (key && value) {
-                        // Remove quotes from the value
-                        dotenv[key.trim()] = value.replace(/(^"|"$)/g, '').trim();
+                        // Remove quotes from the beginning and end of the value.
+                        dotenv[key.trim()] = value.replace(/(^"|"$)/g, '');
                     }
                 }
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -52235,7 +52235,7 @@ async function run() {
         if (environment) {
             // Open the environment.
             coreExports.startGroup(`Opening ESC environment: ${environment}`);
-            const result = await execExports.getExecOutput('esc', ['open', environment, '--format', 'dotenv'], { silent: true, ignoreReturnCode: true });
+            const result = await execExports.getExecOutput('esc', ['open', environment, '--format', 'json'], { silent: true, ignoreReturnCode: true });
             if (result.exitCode !== 0) {
                 throw new Error(`\`esc open\` command failed:
 ${result.stderr}`);
@@ -52243,20 +52243,7 @@ ${result.stderr}`);
             // Parse the output
             let dotenv = {};
             try {
-                // The output is in the format KEY="VALUE"
-                // We need to convert it to an object
-                const lines = result.stdout.split('\n');
-                for (const line of lines) {
-                    const eq = line.indexOf('=');
-                    if (eq < 0) {
-                        continue;
-                    }
-                    const [key, value] = [line.slice(0, eq), line.slice(eq + 1)];
-                    if (key && value) {
-                        // Remove quotes from the beginning and end of the value.
-                        dotenv[key.trim()] = value.replace(/(^"|"$)/g, '');
-                    }
-                }
+                dotenv = JSON.parse(result.stdout).environmentVariables;
             }
             catch (parseErr) {
                 throw new Error(`Failed to open environment: ${parseErr}`);
@@ -52288,7 +52275,7 @@ ${result.stderr}`);
                         // line1
                         // line2
                         // EOF
-                        require$$1.appendFileSync(envFilePath, `${to}<<EOF\n${value}\nEOF\n`);
+                        require$$1.appendFileSync(envFilePath, `${to}<<PULUMIESCEOL\n${value}\nPULUMIESCEOL\n`);
                         coreExports.info(`Injected ${to}=${from}`);
                     }
                     else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,8 +240,8 @@ ${result.stderr}`)
                     const [key, value] = [line.slice(0, eq), line.slice(eq + 1)];
 
                     if (key && value) {
-                        // Remove quotes from the value
-                        dotenv[key.trim()] = value.replace(/(^"|"$)/g, '').trim();
+                        // Remove quotes from the beginning and end of the value.
+                        dotenv[key.trim()] = value.replace(/(^"|"$)/g, '');
                     }
                 }
             } catch (parseErr) {


### PR DESCRIPTION
The action currently trims values but this can remove meaningful whitespace. For example, a value containing a PEM-encoded private key _must_ include a trailing newline (RFC 7468). Trimming a value containing a PEM key renders it invalid.

Instead we should return the value as-is, including any whitespace the user specified with it.

This also fixes an issue where if "EOF" appeared anywhere in the value it would cause the value to not be set in the environment because GitHub's parsing doesn't seem to handle that correctly (I'm working on a repro to confirm). Instead we use a more distinct "PULUMIESCEOF" delimiter which is practically guaranteed to never appear in the wild.

Refs https://github.com/pulumi/ci-mgmt/issues/1481