### PR TITLE
Add missing inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ For case (3), each _export mapping_ takes one of the following three forms:
 
 **Optional** The type of Pulumi Access Token to obtain. Reqiured if `oidc-auth` is true.
 
-### `oidc-scope` (`ESC_OIDC_SCOPE`)
+### `oidc-scope` (`ESC_ACTION_OIDC_SCOPE`)
 
 **Optional** The requested scopes for the Pulumi Access Token.
 
-### `oidc-expiration` (`ESC_OIDC_EXPIRATION`)
+### `oidc-expiration` (`ESC_ACTION_OIDC_TOKEN_EXPIRATION`)
 
 **Optional** The time-to-live for the Pulumi Access Token.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For case (3), each _export mapping_ takes one of the following three forms:
 
 **Optional** The requested scopes for the Pulumi Access Token.
 
-### `oidc-expiration` (`ESC_ACTION_OIDC_TOKEN_EXPIRATION`)
+### `oidc-token-expiration` (`ESC_ACTION_OIDC_TOKEN_EXPIRATION`)
 
 **Optional** The time-to-live for the Pulumi Access Token.
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,26 @@ inputs:
   export-environment-variables:
     description: "Whether or not to export environment variables. All environment variables will always be available in the 'env' step output."
     required: false
+  oidc-auth:
+    description: 'When true, the ESC action will exchange the GitHub workflow OIDC token for a Pulumi Access Token. Requires id-token: write permission.'
+    required: false
+    default: 'false'
+  oidc-organization:
+    description: 'The name of the Pulumi organization to use for OIDC token exchange. Required if oidc-auth is true.'
+    required: false
+    default: ''
+  oidc-requested-token-type:
+    description: 'The type of Pulumi Access Token to obtain. Required if oidc-auth is true.'
+    required: false
+    default: ''
+  oidc-scope:
+    description: 'The requested scopes for the Pulumi Access Token.'
+    required: false
+    default: ''
+  oidc-expiration:
+    description: 'The time-to-live for the Pulumi Access Token.'
+    required: false
+    default: ''
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     description: 'The requested scopes for the Pulumi Access Token.'
     required: false
     default: ''
-  oidc-expiration:
+  oidc-token-expiration:
     description: 'The time-to-live for the Pulumi Access Token.'
     required: false
     default: ''


### PR DESCRIPTION
The README describes some inputs which are actually only usable via environment variables. 

This fixes the action to actually accept them as inputs, which is generally preferred because it provides runtime checks.