### PR TITLE
chore: remove critical typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ jobs:
         id: esc-secrets
         uses: pulumi/esc-action@v1
       - name: `pulumi up`
-        run: pululmi up
+        run: pulumi up
         env:
           PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.ORG_TOKEN }}
   job-2:


### PR DESCRIPTION
This pull request fixes a critical typo in the GitHub Actions workflow documentation, correcting the command for running Pulumi.

* Corrected the `run` command from `pululmi up` to `pulumi up` in the `README.md` file to ensure the deployment step works as intended.