### PR TITLE
Fix oidc-auth default breaking ESC_ACTION_OIDC_AUTH env-var fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   oidc-auth:
     description: 'When true, the ESC action will exchange the GitHub workflow OIDC token for a Pulumi Access Token. Requires id-token: write permission.'
     required: false
-    default: 'false'
+    default: ''
   oidc-organization:
     description: 'The name of the Pulumi organization to use for OIDC token exchange. Required if oidc-auth is true.'
     required: false


### PR DESCRIPTION
## Summary

Regression introduced in #35: `oidc-auth` was declared in `action.yml` with `default: 'false'`. Because `getInput()` in `src/index.ts` uses `core.getInput(name) || process.env['ESC_ACTION_' + envVar]`, the non-empty string `'false'` short-circuits the env-var fallback and silently disables OIDC auth for consumers configuring the action via `ESC_ACTION_OIDC_AUTH`.

Fix: default `oidc-auth` to `''`, matching the other `oidc-*` inputs, so `core.getInput` returns falsy and the env-var fallback works again.

Fixes #42 — see the issue for symptoms, repro, and impact.

## Why `''`, not a truthy-check in `getInput()`

An alternative is to keep `default: 'false'` and instead treat a literal `'false'` as "unset" inside `getInput()`. Rejected because:

- `@actions/core` cannot distinguish `with: oidc-auth: false` from "user passed nothing and the action.yml default fired" — the runner sets `INPUT_OIDC_AUTH=false` in both cases. Any "treat 'false' as unset" rule has to pick one interpretation, and the obvious pick (`with:` explicit value wins) is exactly the one we can't detect.
- Doing the string check anyway flips precedence in a surprising way: `with: oidc-auth: false` combined with `env: ESC_ACTION_OIDC_AUTH=true` would resolve to `true`, contradicting the documented "input overrides env" behavior.
- The rule would live in shared `getInput()` and apply to every input, affecting any future non-boolean input where the literal string `"false"` is a legitimate user value.
- It papers over the root cause (a misleading default in action.yml) instead of fixing it.

Defaulting to `''` removes the ambiguity at the source and keeps `getInput()` simple.

## Test plan

- [ ] Workflow with only `env: ESC_ACTION_OIDC_AUTH: true` (no `with:`) authenticates via OIDC.
- [ ] Workflow with explicit `with: oidc-auth: true` authenticates via OIDC.
- [ ] Workflow with explicit `with: oidc-auth: false` skips OIDC.
- [ ] Workflow with neither still skips OIDC (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)