### PR TITLE
Add `mask: secrets` to mask only encrypted ESC values

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ config can turn `8,561,234` into `8,56***` or `$1.3559` into `$***.3559`.
 Set `mask: secrets` to mask **only** values that come from encrypted/secret ESC
 sources. Plaintext config is then exported and shown in the clear, so the
 collateral redaction above goes away. Secret detection uses
-`esc open --format detailed`, which annotates each value with whether it resolved
+`pulumi env open --format detailed`, which annotates each value with whether it resolved
 from a secret source (the `dotenv` output used for injection carries no such
 signal).
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ For case (3), each _export mapping_ takes one of the following three forms:
 2. `SECRET`, which maps the ESC secret named `SECRET` to the environment variable `SECRET` (equivalent to `SECRET=SECRET`)
 3. `*`, which adds identity mappings for any unmapped secrets
 
+### `mask` (`ESC_ACTION_MASK`)
+
+**Optional** Which injected values to register as masked secrets in the workflow
+logs. Defaults to `all`.
+
+1. `all` (default) — every injected value is masked, preserving today's behavior.
+2. `secrets` — only values that come from encrypted/secret ESC sources are masked;
+   plaintext config values stay readable.
+
+See [Masking behavior](#masking-behavior) for details and the tradeoffs.
+
 ### `oidc-auth` (`ESC_ACTION_OIDC_AUTH`)
 
 **Optional** When this input is `true`, the ESC action will exchange the GitHub workflow's OIDC token for a Pulumi Access Token. This token is not available to other steps. Requires `id-token: write` permission.
@@ -71,6 +82,38 @@ For case (3), each _export mapping_ takes one of the following three forms:
 ### `keys` (`ESC_ACTION_KEYS`)
 
 **Optional** (_Deprecated in favor of export-environment-variables_) A comma-separated list of keys to inject into the current action/workflow environment. If not specified, all keys from the environment will be injected.
+
+## Masking behavior
+
+By default (`mask: all`), every value injected from the ESC environment is
+registered as a masked secret (via `::add-mask::`). The GitHub Actions runner then
+masks **every substring occurrence** of each registered value across the run logs
+**and** `$GITHUB_STEP_SUMMARY`.
+
+That is the right default for secrets, but ESC environments often also export
+**plaintext config** alongside secrets. Masking those config values makes logs
+unreadable, and — because masking is substring-based — it can redact unrelated
+text. For example, if a config value happens to be `9215`, a PR number `9215`
+elsewhere in your logs or job summary is rendered as `92***5`; short numeric
+config can turn `8,561,234` into `8,56***` or `$1.3559` into `$***.3559`.
+
+Set `mask: secrets` to mask **only** values that come from encrypted/secret ESC
+sources. Plaintext config is then exported and shown in the clear, so the
+collateral redaction above goes away. Secret detection uses
+`esc open --format detailed`, which annotates each value with whether it resolved
+from a secret source (the `dotenv` output used for injection carries no such
+signal).
+
+Notes and tradeoffs:
+
+- The default is `all`, so existing workflows are unaffected.
+- `mask: secrets` opens the environment a **second time** (with
+  `--format detailed`) to read the secret markers. If your environment mints
+  dynamic/short-lived credentials, this resolves it twice.
+- `mask: secrets` scopes masking to genuine secrets, which removes the common
+  case of plaintext config redacting your logs. A genuine secret whose value is
+  itself very short or low-entropy can still match unrelated substrings — masking
+  remains correct for it, it is simply still masked.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   export-environment-variables:
     description: "Whether or not to export environment variables. All environment variables will always be available in the 'env' step output."
     required: false
+  mask:
+    description: "Which injected values to register as masked secrets in logs. 'all' (default) masks every value. 'secrets' masks only values that come from encrypted/secret ESC sources, leaving plaintext config readable."
+    required: false
+    default: ''
   oidc-auth:
     description: 'When true, the ESC action will exchange the GitHub workflow OIDC token for a Pulumi Access Token. Requires id-token: write permission.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -52377,8 +52377,8 @@ function parseDotenv(stdout) {
 // redacting unrelated text. `mask: secrets` restricts masking to values that
 // come from encrypted/secret ESC sources.
 //
-// `esc open --format dotenv` (used for the actual values + materialized files)
-// carries no secret-vs-plaintext signal. `esc open --format detailed` encodes
+// `pulumi env open --format dotenv` (used for the actual values + materialized
+// files) carries no secret-vs-plaintext signal. `pulumi env open --format detailed` encodes
 // the full `esc.Value` tree where every node is
 // `{ "value": <data|nested>, "secret"?: true, "trace": {...} }`, so it is the
 // reliable source for which keys are secret.
@@ -52418,7 +52418,7 @@ function nodeContainsSecret(node) {
     }
     return false;
 }
-// Given the stdout of `esc open --format detailed`, return the set of keys --
+// Given the stdout of `pulumi env open --format detailed`, return the set of keys --
 // across `environmentVariables` and `files`, the two sections that become env
 // vars -- whose value came from a secret source. Throws if the output is not
 // valid JSON (the caller fails the action rather than risk leaking secrets);
@@ -52430,7 +52430,7 @@ function collectSecretKeys(detailedStdout) {
         root = JSON.parse(detailedStdout);
     }
     catch {
-        throw new Error('Could not parse `esc open --format detailed` output as JSON.');
+        throw new Error('Could not parse `pulumi env open --format detailed` output as JSON.');
     }
     const top = isObject(root) ? root.value : undefined;
     if (!isObject(top)) {
@@ -52662,10 +52662,10 @@ ${result.stderr}`);
             // only extra work `mask: secrets` adds; `mask: all` skips it entirely.
             let secretKeys = null;
             if (maskMode === 'secrets') {
-                coreExports.info('Determining which values are secret (esc open --format detailed)');
-                const detailed = await execExports.getExecOutput('esc', ['open', environment, '--format', 'detailed'], { silent: true, ignoreReturnCode: true });
+                coreExports.info('Determining which values are secret (pulumi env open --format detailed)');
+                const detailed = await execExports.getExecOutput('pulumi', ['env', 'open', environment, '--format', 'detailed'], { silent: true, ignoreReturnCode: true });
                 if (detailed.exitCode !== 0) {
-                    throw new Error(`\`esc open --format detailed\` command failed:
+                    throw new Error(`\`pulumi env open --format detailed\` command failed:
 ${detailed.stderr}`);
                 }
                 secretKeys = collectSecretKeys(detailed.stdout);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29961,7 +29961,7 @@ const isNumber = typeOfTest('number');
  *
  * @returns {boolean} True if value is an Object, otherwise false
  */
-const isObject = (thing) => thing !== null && typeof thing === 'object';
+const isObject$1 = (thing) => thing !== null && typeof thing === 'object';
 
 /**
  * Determine if a value is a Boolean
@@ -30030,7 +30030,7 @@ const isFileList = kindOfTest('FileList');
  *
  * @returns {boolean} True if value is a Stream, otherwise false
  */
-const isStream = (val) => isObject(val) && isFunction(val.pipe);
+const isStream = (val) => isObject$1(val) && isFunction(val.pipe);
 
 /**
  * Determine if a value is a FormData
@@ -30470,7 +30470,7 @@ const toJSONObject = (obj) => {
 
   const visit = (source, i) => {
 
-    if (isObject(source)) {
+    if (isObject$1(source)) {
       if (stack.indexOf(source) >= 0) {
         return;
       }
@@ -30499,7 +30499,7 @@ const toJSONObject = (obj) => {
 const isAsyncFn = kindOfTest('AsyncFunction');
 
 const isThenable = (thing) =>
-  thing && (isObject(thing) || isFunction(thing)) && isFunction(thing.then) && isFunction(thing.catch);
+  thing && (isObject$1(thing) || isFunction(thing)) && isFunction(thing.then) && isFunction(thing.catch);
 
 // original code
 // https://github.com/DigitalBrainJS/AxiosPromise/blob/16deab13710ec09779922131f3fa5954320f83ab/lib/utils.js#L11-L34
@@ -30544,7 +30544,7 @@ var utils$1 = {
   isString,
   isNumber,
   isBoolean,
-  isObject,
+  isObject: isObject$1,
   isPlainObject,
   isReadableStream,
   isRequest,
@@ -52368,6 +52368,89 @@ function parseDotenv(stdout) {
     return dotenv;
 }
 
+// Selective masking of injected ESC values.
+//
+// By default the action registers every injected value as a masked secret
+// (`mask: all`). The GitHub runner then masks every *substring* match of each
+// registered value across the run logs and `$GITHUB_STEP_SUMMARY`, so plaintext
+// config that ESC also exports gets masked too -- making logs unreadable and
+// redacting unrelated text. `mask: secrets` restricts masking to values that
+// come from encrypted/secret ESC sources.
+//
+// `esc open --format dotenv` (used for the actual values + materialized files)
+// carries no secret-vs-plaintext signal. `esc open --format detailed` encodes
+// the full `esc.Value` tree where every node is
+// `{ "value": <data|nested>, "secret"?: true, "trace": {...} }`, so it is the
+// reliable source for which keys are secret.
+// Parse the `mask` input. Empty/unset defaults to 'all' (today's behavior, so
+// the env-var fallback keeps working -- see action.yml). Anything other than
+// the two documented values is rejected rather than silently treated as a mode.
+function parseMaskMode(raw) {
+    const val = (raw ?? '').trim();
+    if (val === '' || val === 'all') {
+        return 'all';
+    }
+    if (val === 'secrets') {
+        return 'secrets';
+    }
+    throw new Error(`Invalid value for 'mask': '${raw}'. Must be 'all' or 'secrets'.`);
+}
+function isObject(v) {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+// A detailed node represents a secret if it -- or any nested node beneath it --
+// is marked secret. Environment-variable and file values are scalars in
+// practice, so this is usually just a flag check; the recursion is defensive.
+function nodeContainsSecret(node) {
+    if (!isObject(node)) {
+        return false;
+    }
+    const detailed = node;
+    if (detailed.secret === true) {
+        return true;
+    }
+    const inner = detailed.value;
+    if (Array.isArray(inner)) {
+        return inner.some(nodeContainsSecret);
+    }
+    if (isObject(inner)) {
+        return Object.values(inner).some(nodeContainsSecret);
+    }
+    return false;
+}
+// Given the stdout of `esc open --format detailed`, return the set of keys --
+// across `environmentVariables` and `files`, the two sections that become env
+// vars -- whose value came from a secret source. Throws if the output is not
+// valid JSON (the caller fails the action rather than risk leaking secrets);
+// tolerates missing sections by returning what it can.
+function collectSecretKeys(detailedStdout) {
+    const keys = new Set();
+    let root;
+    try {
+        root = JSON.parse(detailedStdout);
+    }
+    catch {
+        throw new Error('Could not parse `esc open --format detailed` output as JSON.');
+    }
+    const top = isObject(root) ? root.value : undefined;
+    if (!isObject(top)) {
+        return keys;
+    }
+    for (const section of ['environmentVariables', 'files']) {
+        const sectionNode = top[section];
+        const entries = isObject(sectionNode) ? sectionNode.value : undefined;
+        if (!isObject(entries)) {
+            continue;
+        }
+        for (const [key, node] of Object.entries(entries)) {
+            if (nodeContainsSecret(node)) {
+                keys.add(key);
+            }
+        }
+    }
+    return keys;
+}
+
 // axios-retry v4 exports as CJS, need to access default export
 const axiosRetry = axiosRetry$1 || axiosRetryModule;
 const { exponentialDelay, isNetworkOrIdempotentRequestError } = axiosRetryModule;
@@ -52529,6 +52612,7 @@ async function run() {
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
+        const maskMode = parseMaskMode(getInput('mask', 'MASK'));
         const [mapping, allVars] = getExportEnvironmentVariables(keys);
         const useOidcAuth = getBooleanInput('oidc-auth', 'OIDC_AUTH');
         if (useOidcAuth) {
@@ -52570,9 +52654,28 @@ async function run() {
 ${result.stderr}`);
             }
             const dotenv = parseDotenv(result.stdout);
-            // Populate step outputs and mark secrets so they do not appear in logs.
+            // When masking only secrets, open the environment a second time with
+            // `--format detailed` to learn which keys came from a secret source --
+            // the dotenv output carries no secret-vs-plaintext signal. This is the
+            // only extra work `mask: secrets` adds; `mask: all` skips it entirely.
+            let secretKeys = null;
+            if (maskMode === 'secrets') {
+                coreExports.info('Determining which values are secret (esc open --format detailed)');
+                const detailed = await execExports.getExecOutput('esc', ['open', environment, '--format', 'detailed'], { silent: true, ignoreReturnCode: true });
+                if (detailed.exitCode !== 0) {
+                    throw new Error(`\`esc open --format detailed\` command failed:
+${detailed.stderr}`);
+                }
+                secretKeys = collectSecretKeys(detailed.stdout);
+            }
+            // Populate step outputs and mask values so they do not appear in logs.
+            // Every key is always available as a step output; only masking is gated
+            // by `mask`. With `mask: all` (the default) every value is masked, exactly
+            // as before.
             for (const [key, value] of Object.entries(dotenv)) {
-                coreExports.setSecret(value);
+                if (maskMode === 'all' || secretKeys.has(key)) {
+                    coreExports.setSecret(value);
+                }
                 coreExports.setOutput(key, value);
             }
             // Calculate the final set of mappings. If allVars is true, add identity mappings for all unmapped variables;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 import * as axiosRetryModule from 'axios-retry';
 import axios from 'axios';
 import { parseDotenv } from './parse-dotenv.js';
+import { collectSecretKeys, parseMaskMode } from './mask.js';
 
 // axios-retry v4 exports as CJS, need to access default export
 const axiosRetry = (axiosRetryModule as any).default || axiosRetryModule;
@@ -202,6 +203,7 @@ async function run(): Promise<void> {
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
+        const maskMode = parseMaskMode(getInput('mask', 'MASK'));
         const [mapping, allVars] = getExportEnvironmentVariables(keys);
 
         const useOidcAuth = getBooleanInput('oidc-auth', 'OIDC_AUTH');
@@ -254,9 +256,33 @@ ${result.stderr}`)
 
             const dotenv = parseDotenv(result.stdout);
 
-            // Populate step outputs and mark secrets so they do not appear in logs.
+            // When masking only secrets, open the environment a second time with
+            // `--format detailed` to learn which keys came from a secret source --
+            // the dotenv output carries no secret-vs-plaintext signal. This is the
+            // only extra work `mask: secrets` adds; `mask: all` skips it entirely.
+            let secretKeys: Set<string> | null = null;
+            if (maskMode === 'secrets') {
+                core.info('Determining which values are secret (esc open --format detailed)');
+                const detailed = await exec.getExecOutput(
+                    'esc',
+                    ['open', environment, '--format', 'detailed'],
+                    { silent: true, ignoreReturnCode: true }
+                );
+                if (detailed.exitCode !== 0) {
+                    throw new Error(`\`esc open --format detailed\` command failed:
+${detailed.stderr}`)
+                }
+                secretKeys = collectSecretKeys(detailed.stdout);
+            }
+
+            // Populate step outputs and mask values so they do not appear in logs.
+            // Every key is always available as a step output; only masking is gated
+            // by `mask`. With `mask: all` (the default) every value is masked, exactly
+            // as before.
             for (const [key, value] of Object.entries(dotenv)) {
-                core.setSecret(value);
+                if (maskMode === 'all' || secretKeys!.has(key)) {
+                    core.setSecret(value);
+                }
                 core.setOutput(key, value);
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,14 +265,14 @@ ${result.stderr}`)
             // only extra work `mask: secrets` adds; `mask: all` skips it entirely.
             let secretKeys: Set<string> | null = null;
             if (maskMode === 'secrets') {
-                core.info('Determining which values are secret (esc open --format detailed)');
+                core.info('Determining which values are secret (pulumi env open --format detailed)');
                 const detailed = await exec.getExecOutput(
-                    'esc',
-                    ['open', environment, '--format', 'detailed'],
+                    'pulumi',
+                    ['env', 'open', environment, '--format', 'detailed'],
                     { silent: true, ignoreReturnCode: true }
                 );
                 if (detailed.exitCode !== 0) {
-                    throw new Error(`\`esc open --format detailed\` command failed:
+                    throw new Error(`\`pulumi env open --format detailed\` command failed:
 ${detailed.stderr}`)
                 }
                 secretKeys = collectSecretKeys(detailed.stdout);

--- a/src/mask.test.ts
+++ b/src/mask.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { collectSecretKeys, parseMaskMode } from './mask.js';
 
-// A representative slice of `esc open --format detailed` output: the root is the
+// A representative slice of `pulumi env open --format detailed` output: the root is the
 // opened environment's esc.Value, and every node is wrapped as
 // `{ "value": ..., "secret"?: true, "trace": {...} }`. Here API_KEY and the
 // KUBECONFIG file resolved from secret sources; LOG_LEVEL is plaintext config.

--- a/src/mask.test.ts
+++ b/src/mask.test.ts
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { collectSecretKeys, parseMaskMode } from './mask.js';
+
+// A representative slice of `esc open --format detailed` output: the root is the
+// opened environment's esc.Value, and every node is wrapped as
+// `{ "value": ..., "secret"?: true, "trace": {...} }`. Here API_KEY and the
+// KUBECONFIG file resolved from secret sources; LOG_LEVEL is plaintext config.
+function detailedFixture(): string {
+    return JSON.stringify({
+        value: {
+            environmentVariables: {
+                value: {
+                    API_KEY: { value: 'abc123', secret: true, trace: {} },
+                    LOG_LEVEL: { value: 'debug', trace: {} }
+                },
+                trace: {}
+            },
+            files: {
+                value: {
+                    KUBECONFIG: { value: '/tmp/esc-kube', secret: true, trace: {} }
+                },
+                trace: {}
+            }
+        },
+        trace: {}
+    });
+}
+
+test('parseMaskMode defaults to all when empty or unset (no regression)', () => {
+    assert.equal(parseMaskMode(undefined), 'all');
+    assert.equal(parseMaskMode(''), 'all');
+    assert.equal(parseMaskMode('all'), 'all');
+});
+
+test('parseMaskMode accepts secrets and trims surrounding whitespace', () => {
+    assert.equal(parseMaskMode('secrets'), 'secrets');
+    assert.equal(parseMaskMode('  secrets  '), 'secrets');
+});
+
+test('parseMaskMode rejects anything else with a clear error', () => {
+    for (const bad of ['secrets-only', 'none', 'true', 'All', 'SECRETS']) {
+        assert.throws(() => parseMaskMode(bad), /Invalid value for 'mask'/);
+    }
+});
+
+test('collectSecretKeys returns only keys from secret sources', () => {
+    const keys = collectSecretKeys(detailedFixture());
+    assert.deepEqual([...keys].sort(), ['API_KEY', 'KUBECONFIG']);
+    assert.ok(!keys.has('LOG_LEVEL'), 'plaintext config must not be marked secret');
+});
+
+test('collectSecretKeys tolerates missing sections', () => {
+    const onlyEnv = JSON.stringify({
+        value: {
+            environmentVariables: {
+                value: { TOKEN: { value: 't', secret: true, trace: {} } },
+                trace: {}
+            }
+        },
+        trace: {}
+    });
+    assert.deepEqual([...collectSecretKeys(onlyEnv)], ['TOKEN']);
+
+    // No environmentVariables or files at all -> empty set, no throw.
+    assert.equal(collectSecretKeys(JSON.stringify({ value: {}, trace: {} })).size, 0);
+    assert.equal(collectSecretKeys(JSON.stringify({})).size, 0);
+});
+
+test('collectSecretKeys detects a secret nested under an object value', () => {
+    // Defensive: a non-scalar value whose secret marker sits on a child node.
+    const nested = JSON.stringify({
+        value: {
+            environmentVariables: {
+                value: {
+                    CONFIG: {
+                        value: {
+                            password: { value: 'p', secret: true, trace: {} }
+                        },
+                        trace: {}
+                    }
+                },
+                trace: {}
+            }
+        },
+        trace: {}
+    });
+    assert.deepEqual([...collectSecretKeys(nested)], ['CONFIG']);
+});
+
+test('collectSecretKeys throws on non-JSON output', () => {
+    assert.throws(
+        () => collectSecretKeys('not json at all'),
+        /Could not parse .* as JSON/
+    );
+});

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -1,0 +1,99 @@
+// Selective masking of injected ESC values.
+//
+// By default the action registers every injected value as a masked secret
+// (`mask: all`). The GitHub runner then masks every *substring* match of each
+// registered value across the run logs and `$GITHUB_STEP_SUMMARY`, so plaintext
+// config that ESC also exports gets masked too -- making logs unreadable and
+// redacting unrelated text. `mask: secrets` restricts masking to values that
+// come from encrypted/secret ESC sources.
+//
+// `esc open --format dotenv` (used for the actual values + materialized files)
+// carries no secret-vs-plaintext signal. `esc open --format detailed` encodes
+// the full `esc.Value` tree where every node is
+// `{ "value": <data|nested>, "secret"?: true, "trace": {...} }`, so it is the
+// reliable source for which keys are secret.
+
+export type MaskMode = 'all' | 'secrets';
+
+// Parse the `mask` input. Empty/unset defaults to 'all' (today's behavior, so
+// the env-var fallback keeps working -- see action.yml). Anything other than
+// the two documented values is rejected rather than silently treated as a mode.
+export function parseMaskMode(raw: string | undefined): MaskMode {
+    const val = (raw ?? '').trim();
+    if (val === '' || val === 'all') {
+        return 'all';
+    }
+    if (val === 'secrets') {
+        return 'secrets';
+    }
+    throw new Error(`Invalid value for 'mask': '${raw}'. Must be 'all' or 'secrets'.`);
+}
+
+// A node in `esc open --format detailed` output. The `value` field holds the
+// resolved data (a scalar, an array of nodes, or an object mapping keys to
+// nodes), and `secret` is true when the node resolved from a secret source.
+interface DetailedNode {
+    value?: unknown;
+    secret?: boolean;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// A detailed node represents a secret if it -- or any nested node beneath it --
+// is marked secret. Environment-variable and file values are scalars in
+// practice, so this is usually just a flag check; the recursion is defensive.
+function nodeContainsSecret(node: unknown): boolean {
+    if (!isObject(node)) {
+        return false;
+    }
+    const detailed = node as DetailedNode;
+    if (detailed.secret === true) {
+        return true;
+    }
+    const inner = detailed.value;
+    if (Array.isArray(inner)) {
+        return inner.some(nodeContainsSecret);
+    }
+    if (isObject(inner)) {
+        return Object.values(inner).some(nodeContainsSecret);
+    }
+    return false;
+}
+
+// Given the stdout of `esc open --format detailed`, return the set of keys --
+// across `environmentVariables` and `files`, the two sections that become env
+// vars -- whose value came from a secret source. Throws if the output is not
+// valid JSON (the caller fails the action rather than risk leaking secrets);
+// tolerates missing sections by returning what it can.
+export function collectSecretKeys(detailedStdout: string): Set<string> {
+    const keys = new Set<string>();
+
+    let root: unknown;
+    try {
+        root = JSON.parse(detailedStdout);
+    } catch {
+        throw new Error('Could not parse `esc open --format detailed` output as JSON.');
+    }
+
+    const top = isObject(root) ? root.value : undefined;
+    if (!isObject(top)) {
+        return keys;
+    }
+
+    for (const section of ['environmentVariables', 'files']) {
+        const sectionNode = top[section];
+        const entries = isObject(sectionNode) ? sectionNode.value : undefined;
+        if (!isObject(entries)) {
+            continue;
+        }
+        for (const [key, node] of Object.entries(entries)) {
+            if (nodeContainsSecret(node)) {
+                keys.add(key);
+            }
+        }
+    }
+
+    return keys;
+}

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -7,8 +7,8 @@
 // redacting unrelated text. `mask: secrets` restricts masking to values that
 // come from encrypted/secret ESC sources.
 //
-// `esc open --format dotenv` (used for the actual values + materialized files)
-// carries no secret-vs-plaintext signal. `esc open --format detailed` encodes
+// `pulumi env open --format dotenv` (used for the actual values + materialized
+// files) carries no secret-vs-plaintext signal. `pulumi env open --format detailed` encodes
 // the full `esc.Value` tree where every node is
 // `{ "value": <data|nested>, "secret"?: true, "trace": {...} }`, so it is the
 // reliable source for which keys are secret.
@@ -29,7 +29,7 @@ export function parseMaskMode(raw: string | undefined): MaskMode {
     throw new Error(`Invalid value for 'mask': '${raw}'. Must be 'all' or 'secrets'.`);
 }
 
-// A node in `esc open --format detailed` output. The `value` field holds the
+// A node in `pulumi env open --format detailed` output. The `value` field holds the
 // resolved data (a scalar, an array of nodes, or an object mapping keys to
 // nodes), and `secret` is true when the node resolved from a secret source.
 interface DetailedNode {
@@ -62,7 +62,7 @@ function nodeContainsSecret(node: unknown): boolean {
     return false;
 }
 
-// Given the stdout of `esc open --format detailed`, return the set of keys --
+// Given the stdout of `pulumi env open --format detailed`, return the set of keys --
 // across `environmentVariables` and `files`, the two sections that become env
 // vars -- whose value came from a secret source. Throws if the output is not
 // valid JSON (the caller fails the action rather than risk leaking secrets);
@@ -74,7 +74,7 @@ export function collectSecretKeys(detailedStdout: string): Set<string> {
     try {
         root = JSON.parse(detailedStdout);
     } catch {
-        throw new Error('Could not parse `esc open --format detailed` output as JSON.');
+        throw new Error('Could not parse `pulumi env open --format detailed` output as JSON.');
     }
 
     const top = isObject(root) ? root.value : undefined;


### PR DESCRIPTION
## Summary

By default the action registers every injected value as a masked secret, so the GitHub runner masks every substring match across logs and the step summary. Environments often also export plaintext config, which then gets masked too -- making logs unreadable and redacting unrelated text (e.g. a config value `9215` turns a PR number `9215` elsewhere into `92***5`).

Resolves #24.

## Changes

Adds a `mask` input (`ESC_ACTION_MASK`):

- `all` (default): mask every value -- unchanged behavior.
- `secrets`: mask only values that resolve from encrypted/secret ESC sources, leaving plaintext config readable.

Default is `all`, so existing workflows are unaffected.

## How `secrets` mode detects secret values

`pulumi env open --format dotenv` (used for the actual values + materialized files) carries no secret-vs-plaintext signal. In `secrets` mode the action opens the environment a second time with `--format detailed`, whose `esc.Value` tree marks each node `"secret": true` when it came from a secret source. That tree is the reliable source for which keys are secret.

This extra open only runs in `secrets` mode -- `mask: all` skips it entirely.

If the detailed open fails, the action fails the step rather than fall back to "don't mask" and risk leaking a secret.

## Implementation notes

- Parsing the detailed format happens in a small pure module ([src/mask.ts](src/mask.ts)) with unit tests in [src/mask.test.ts](src/mask.test.ts) covering nested objects, arrays, the `environmentVariables`/`files` sections, missing/empty sections, and an unknown `mask` value being rejected rather than silently treated as a mode.
- An unknown `mask` value (anything other than `all`/`secrets`/empty) fails fast with a clear error -- silently defaulting could mask the wrong set of values.