### PR TITLE
Update action runtime to Node.js 24 (fixes #40)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Run unit tests

--- a/action.yml
+++ b/action.yml
@@ -45,5 +45,5 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-typescript": "^12.1.2",
-        "@types/node": "^22.13.5",
+        "@types/node": "^24.0.0",
         "prettier": "^3.3.3",
         "rollup": "^4.40.0",
         "tsx": "^4.21.0",
@@ -1864,12 +1864,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -4737,9 +4737,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
-    "@types/node": "^22.13.5",
+    "@types/node": "^24.0.0",
     "prettier": "^3.3.3",
     "rollup": "^4.40.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary
- Switch `action.yml` runtime from `node20` to `node24` ahead of GitHub Actions' June 2, 2026 cutover.
- Bump `@types/node` dev dependency to `^24.0.0` and refresh `package-lock.json`.
- Update the `unit-tests` workflow to install Node 24 to match the action runtime.

Fixes #40

## Test plan
- [x] `npm run build` regenerates an identical `dist/index.js` (no diff)
- [x] `npm test` — all 14 tests pass on Node 24
- [ ] CI green (check-dist + main workflows)
- [ ] Verify a downstream workflow no longer emits the Node 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)