### PR TITLE
Use the Pulumi CLI (`pulumi esc`) instead of the standalone ESC CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,22 +24,22 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Install ESC CLI
+      - name: Install Pulumi CLI
         uses: ./
       - name: Verify CLI exists
-        run: esc version
+        run: pulumi version
   test-cli-download-specific-version:
     strategy: {matrix: {os: [ubuntu-latest, windows-latest]}}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Install ESC CLI
+      - name: Install Pulumi CLI
         uses: ./
         with:
-          version: '0.10.0'
+          version: '3.246.0'
       - name: Verify CLI exists
-        run: esc version
+        run: pulumi version
   test-individual-keys:
     strategy: {matrix: {os: [ubuntu-latest]}}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ With ESC's support for dynamic credentials and automatic secret rotation, you ca
 
 ## Functionality
 
-- If no inputs are passed, this action will download the latest version of the Pulumi ESC CLI for direct use in later steps of the workflow. 
-- If a version is specified, that specific version of the CLI will be downloaded.
+- If no inputs are passed, this action will download the latest version of the Pulumi CLI for direct use in later steps of the workflow. ESC functionality is provided by the `pulumi esc` subcommands.
+- If a version is specified, that specific version of the Pulumi CLI will be downloaded.
 - If an `environment` is passed in as an input, the action will inject all environment variables (specifically the keys under `environmentVariables` and projected files under `files`) from the environment into the current action/workflow environment.
 - If mappings are passed via the `export-environment-variables` input - only the mapped secrets from the environment's `environmentVariables` or `files` objects will be injected into the current action.
 - All secrets from the environment's `environmentVariable` and `files` objects are available as step outputs
@@ -20,7 +20,7 @@ _NOTE_: All parameters can be passed via environment variables as well as inputs
 
 ### `version` (`ESC_ACTION_VERSION`)
 
-**Optional** The version of the ESC CLI to download. If not specified, the latest version will be downloaded.
+**Optional** The version of the Pulumi CLI to download (e.g. `3.246.0`). If not specified, the latest version will be downloaded.
 
 ### `environment` (`ESC_ACTION_ENVIRONMENT`)
 
@@ -74,24 +74,24 @@ For case (3), each _export mapping_ takes one of the following three forms:
 
 ## Example usage
 
-### Download the latest version of the ESC CLI
+### Download the latest version of the Pulumi CLI
 
 ```yaml
-uses: pulumi/esc-action@v2
+uses: pulumi/esc-action@v3
 ```
 
-### Download a specific version of the ESC CLI
+### Download a specific version of the Pulumi CLI
 
 ```yaml
-uses: pulumi/esc-action@v2
+uses: pulumi/esc-action@v3
 with:
-  version: 0.10.0
+  version: 3.246.0
 ```
 
 ### Open an environment and inject all environment variables
 
 ```yaml
-uses: pulumi/esc-action@v2
+uses: pulumi/esc-action@v3
 with:
   environment: my-org/my-project/my-env
 env:
@@ -101,7 +101,7 @@ env:
 ### Open an environment and inject specific environment variables
 
 ```yaml
-uses: pulumi/esc-action@v2
+uses: pulumi/esc-action@v3
 with:
   environment: my-org/my-project/my-env
   export-environment-variables: SOME_KEY,ANOTHER_KEY,LAST_KEY
@@ -133,7 +133,7 @@ jobs:
           organization: pulumi
           requested-token-type: urn:pulumi:token-type:access_token:organization
       - name: Install and inject ESC environment variables
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
         with:
           environment: 'pulumi/github/esc-action'
       - name: Verify environment variables were injected
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v2
+        uses: pulumi/esc-action@v3
       - name: pulumi up
         run: pulumi up
         env:
@@ -173,7 +173,7 @@ jobs:
   job-2:
     runs-on: ubuntu-latest
     steps:
-      - uses: pulumi/esc-action@v2
+      - uses: pulumi/esc-action@v3
       - name: list buckets
         run: aws s3 ls
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
 name: esc-action
-description: GitHub Action to install the ESC CLI and inject environment variables from an ESC environment.
+description: GitHub Action to install the Pulumi CLI and inject environment variables from an ESC environment.
 branding:
   icon: unlock
   color: purple
 author: Pulumi
 inputs:
   version:
-    description: 'Version of ESC CLI to install. If omitted, installs the latest.'
+    description: 'Version of the Pulumi CLI to install (e.g. "3.246.0"). If omitted, installs the latest.'
     required: false
     default: ''
   environment:

--- a/dist/index.js
+++ b/dist/index.js
@@ -52324,7 +52324,7 @@ var axiosRetryModule = /*#__PURE__*/Object.freeze({
 	retryAfter: retryAfter
 });
 
-// Parse the output of `esc open --format dotenv`.
+// Parse the output of `pulumi esc open --format dotenv`.
 //
 // The CLI emits one entry per line as `KEY="VALUE"`, where VALUE is the
 // Go strconv.Quote encoding of the original string. That encoding uses
@@ -52467,12 +52467,12 @@ function getExportEnvironmentVariables(keys) {
     return [mappings, all];
 }
 async function getInstalledVersion() {
-    const installed = await ioExports.which('esc');
+    const installed = await ioExports.which('pulumi');
     if (!installed) {
         return undefined;
     }
     // Return version without 'v' prefix
-    const { exitCode, stdout } = await execExports.getExecOutput('esc', ['version']);
+    const { exitCode, stdout } = await execExports.getExecOutput('pulumi', ['version']);
     if (exitCode === 0 && stdout.trim().startsWith('v')) {
         return stdout.trim().substring(1);
     }
@@ -52481,32 +52481,34 @@ async function getInstalledVersion() {
 async function install(version) {
     const installedVersion = await getInstalledVersion();
     if (installedVersion === version) {
-        coreExports.info('ESC CLI is already installed, skipping installation step.');
+        coreExports.info('Pulumi CLI is already installed, skipping installation step.');
         return;
     }
-    coreExports.startGroup(`Installing ESC CLI v${version}`);
+    coreExports.startGroup(`Installing Pulumi CLI v${version}`);
     if (installedVersion) {
-        coreExports.info(`Already-installed ESC CLI is not version ${version}`);
+        coreExports.info(`Already-installed Pulumi CLI is not version ${version}`);
     }
-    const tmp = require$$1.mkdtempSync('esc-');
-    const destination = require$$1$1.join(require$$0$1.homedir(), '.pulumi', 'esc', 'bin');
+    const tmp = require$$1.mkdtempSync('pulumi-');
+    const destination = require$$1$1.join(require$$0$1.homedir(), '.pulumi', 'bin');
     coreExports.info(`Install destination is ${destination}`);
     await ioExports.mkdirP(destination);
     coreExports.debug(`Successfully created ${destination}`);
     const [platform, arch, ext] = coreExports.platform.platform === 'win32' ? ['windows', 'x64', 'zip'] : [coreExports.platform.platform, coreExports.platform.arch, 'tar.gz'];
-    const downloadURL = `https://get.pulumi.com/esc/releases/esc-v${version}-${platform}-${arch}.${ext}`;
+    const downloadURL = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${platform}-${arch}.${ext}`;
     coreExports.info(`downloading ${downloadURL}`);
     const downloaded = await toolCacheExports.downloadTool(downloadURL);
     coreExports.info(`successfully downloaded ${downloadURL} to ${downloaded}`);
-    const [extract, bin, srcDir] = platform === 'windows' ? [toolCacheExports.extractZip, 'esc.exe', 'bin'] : [toolCacheExports.extractTar, 'esc', ''];
+    // The Pulumi CLI archive bundles the `pulumi` binary alongside its language
+    // plugins. Unix tarballs place them directly under `pulumi/`; Windows zips
+    // nest them under `pulumi/bin/`. We install the whole directory so the full
+    // CLI (not just `pulumi esc`) is available to later workflow steps.
+    const [extract, srcDir] = platform === 'windows' ? [toolCacheExports.extractZip, require$$1$1.join('pulumi', 'bin')] : [toolCacheExports.extractTar, 'pulumi'];
     const extractedPath = await extract(downloaded, tmp);
     coreExports.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
-    const oldPath = require$$1$1.join(tmp, 'esc', srcDir, bin);
-    const newPath = require$$1$1.join(destination, bin);
-    await ioExports.cp(oldPath, newPath);
-    await ioExports.rmRF(oldPath);
-    coreExports.info(`Successfully moved ${oldPath} to ${newPath}`);
-    const cachedPath = await toolCacheExports.cacheDir(destination, 'esc', version);
+    const binDir = require$$1$1.join(tmp, srcDir);
+    await ioExports.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
+    coreExports.info(`Successfully moved ${binDir} to ${destination}`);
+    const cachedPath = await toolCacheExports.cacheDir(destination, 'pulumi', version);
     coreExports.addPath(cachedPath);
     coreExports.endGroup();
 }
@@ -52525,7 +52527,7 @@ async function run() {
             },
         });
         // Parse inputs
-        const escVersion = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/esc/latest-version').then(r => r.text()).then(t => t.trim());
+        const pulumiVersion = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/latest-version').then(r => r.text()).then(t => t.trim());
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
@@ -52541,14 +52543,14 @@ async function run() {
             process.env.PULUMI_ACCESS_TOKEN = accessToken;
         }
         /*
-          Install ESC CLI (either the latest or a specific version)
+          Install the Pulumi CLI (either the latest or a specific version).
 
-          The official installation script supports an optional `--version` argument to pin a release.
-          e.g. curl -fsSL https://get.pulumi.com/esc/install.sh | sh -s -- --version 0.10.0
-
-          If no version is specified, it installs the latest automatically.
+          ESC functionality is exposed through the `pulumi esc` (alias of
+          `pulumi env`) subcommands of the Pulumi CLI, so we download the CLI
+          release archive directly. If no version is specified, the latest is
+          installed automatically.
         */
-        await install(escVersion);
+        await install(pulumiVersion);
         if (cloudUrl) {
             // Set the ESC_CLOUD_URL environment variable if provided
             coreExports.info(`Setting PULUMI_BACKEND_URL to ${cloudUrl}`);
@@ -52564,9 +52566,9 @@ async function run() {
             // temporary file by the CLI and exposed here as an env var
             // pointing at the file's path.
             coreExports.startGroup(`Opening ESC environment: ${environment}`);
-            const result = await execExports.getExecOutput('esc', ['open', environment, '--format', 'dotenv'], { silent: true, ignoreReturnCode: true });
+            const result = await execExports.getExecOutput('pulumi', ['esc', 'open', environment, '--format', 'dotenv'], { silent: true, ignoreReturnCode: true });
             if (result.exitCode !== 0) {
-                throw new Error(`\`esc open\` command failed:
+                throw new Error(`\`pulumi esc open\` command failed:
 ${result.stderr}`);
             }
             const dotenv = parseDotenv(result.stdout);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,14 +1,14 @@
 import * as require$$0$1 from 'os';
 import require$$0__default from 'os';
 import require$$0$2 from 'crypto';
-import * as require$$1 from 'fs';
-import require$$1__default from 'fs';
-import * as require$$1$1 from 'path';
-import require$$1__default$1 from 'path';
+import * as fs from 'fs';
+import fs__default from 'fs';
+import * as path from 'path';
+import path__default from 'path';
 import require$$2 from 'http';
 import require$$3 from 'https';
 import require$$0$5 from 'net';
-import require$$1$2 from 'tls';
+import require$$1 from 'tls';
 import require$$4, { EventEmitter } from 'events';
 import require$$0$4 from 'assert';
 import require$$0$3 from 'util';
@@ -17,20 +17,20 @@ import require$$7 from 'buffer';
 import require$$8 from 'querystring';
 import require$$14 from 'stream/web';
 import require$$0$7 from 'node:stream';
-import require$$1$3 from 'node:util';
+import require$$1$1 from 'node:util';
 import require$$0$6 from 'node:events';
 import require$$0$8 from 'worker_threads';
 import require$$2$1 from 'perf_hooks';
 import require$$5 from 'util/types';
 import require$$4$1 from 'async_hooks';
-import require$$1$4 from 'console';
+import require$$1$2 from 'console';
 import require$$0$9 from 'url';
 import zlib from 'zlib';
 import require$$6 from 'string_decoder';
 import require$$0$a from 'diagnostics_channel';
 import require$$2$2 from 'child_process';
 import require$$6$1 from 'timers';
-import require$$1$5 from 'tty';
+import require$$1$3 from 'tty';
 
 var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
@@ -230,7 +230,7 @@ function requireFileCommand () {
 	// We use any as a valid input type
 	/* eslint-disable @typescript-eslint/no-explicit-any */
 	const crypto = __importStar(require$$0$2);
-	const fs = __importStar(require$$1__default);
+	const fs = __importStar(fs__default);
 	const os = __importStar(require$$0__default);
 	const utils_1 = requireUtils$1();
 	function issueFileCommand(command, message) {
@@ -367,7 +367,7 @@ var hasRequiredTunnel$1;
 function requireTunnel$1 () {
 	if (hasRequiredTunnel$1) return tunnel$1;
 	hasRequiredTunnel$1 = 1;
-	var tls = require$$1$2;
+	var tls = require$$1;
 	var http = require$$2;
 	var https = require$$3;
 	var events = require$$4;
@@ -1749,7 +1749,7 @@ function requireSbmh () {
 	 * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
 	 */
 	const EventEmitter = require$$0$6.EventEmitter;
-	const inherits = require$$1$3.inherits;
+	const inherits = require$$1$1.inherits;
 
 	function SBMH (needle) {
 	  if (typeof needle === 'string') {
@@ -1958,7 +1958,7 @@ function requirePartStream () {
 	if (hasRequiredPartStream) return PartStream_1;
 	hasRequiredPartStream = 1;
 
-	const inherits = require$$1$3.inherits;
+	const inherits = require$$1$1.inherits;
 	const ReadableStream = require$$0$7.Readable;
 
 	function PartStream (opts) {
@@ -2004,7 +2004,7 @@ function requireHeaderParser () {
 	hasRequiredHeaderParser = 1;
 
 	const EventEmitter = require$$0$6.EventEmitter;
-	const inherits = require$$1$3.inherits;
+	const inherits = require$$1$1.inherits;
 	const getLimit = requireGetLimit();
 
 	const StreamSearch = requireSbmh();
@@ -2112,7 +2112,7 @@ function requireDicer () {
 	hasRequiredDicer = 1;
 
 	const WritableStream = require$$0$7.Writable;
-	const inherits = require$$1$3.inherits;
+	const inherits = require$$1$1.inherits;
 
 	const StreamSearch = requireSbmh();
 
@@ -2689,7 +2689,7 @@ function requireMultipart () {
 	//     -- this will require modifications to utils.parseParams
 
 	const { Readable } = require$$0$7;
-	const { inherits } = require$$1$3;
+	const { inherits } = require$$1$1;
 
 	const Dicer = requireDicer();
 
@@ -3255,7 +3255,7 @@ function requireMain () {
 	hasRequiredMain = 1;
 
 	const WritableStream = require$$0$7.Writable;
-	const { inherits } = require$$1$3;
+	const { inherits } = require$$1$1;
 	const Dicer = requireDicer();
 
 	const MultipartParser = requireMultipart();
@@ -8079,7 +8079,7 @@ function requireConnect () {
 	    let socket;
 	    if (protocol === 'https:') {
 	      if (!tls) {
-	        tls = require$$1$2;
+	        tls = require$$1;
 	      }
 	      servername = servername || options.servername || util.getServerName(host) || null;
 
@@ -14089,7 +14089,7 @@ function requirePendingInterceptorsFormatter () {
 	hasRequiredPendingInterceptorsFormatter = 1;
 
 	const { Transform } = stream;
-	const { Console } = require$$1$4;
+	const { Console } = require$$1$2;
 
 	/**
 	 * Gets the output of `console.table(…)` as a string.
@@ -25195,7 +25195,7 @@ function requireSummary () {
 		Object.defineProperty(exports, "__esModule", { value: true });
 		exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
 		const os_1 = require$$0__default;
-		const fs_1 = require$$1__default;
+		const fs_1 = fs__default;
 		const { access, appendFile, writeFile } = fs_1.promises;
 		exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 		exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -25501,7 +25501,7 @@ function requirePathUtils () {
 	};
 	Object.defineProperty(pathUtils, "__esModule", { value: true });
 	pathUtils.toPlatformPath = pathUtils.toWin32Path = pathUtils.toPosixPath = void 0;
-	const path = __importStar(require$$1__default$1);
+	const path = __importStar(path__default);
 	/**
 	 * toPosixPath converts the given path to the posix form. On Windows, \\ will be
 	 * replaced with /.
@@ -25587,8 +25587,8 @@ function requireIoUtil () {
 		var _a;
 		Object.defineProperty(exports, "__esModule", { value: true });
 		exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-		const fs = __importStar(require$$1__default);
-		const path = __importStar(require$$1__default$1);
+		const fs = __importStar(fs__default);
+		const path = __importStar(path__default);
 		_a = fs.promises
 		// export const {open} = 'fs'
 		, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -25778,7 +25778,7 @@ function requireIo () {
 	Object.defineProperty(io, "__esModule", { value: true });
 	io.findInPath = io.which = io.mkdirP = io.rmRF = io.mv = io.cp = void 0;
 	const assert_1 = require$$0$4;
-	const path = __importStar(require$$1__default$1);
+	const path = __importStar(path__default);
 	const ioUtil = __importStar(requireIoUtil());
 	/**
 	 * Copies a file or folder.
@@ -26086,7 +26086,7 @@ function requireToolrunner () {
 	const os = __importStar(require$$0__default);
 	const events = __importStar(require$$4);
 	const child = __importStar(require$$2$2);
-	const path = __importStar(require$$1__default$1);
+	const path = __importStar(path__default);
 	const io = __importStar(requireIo());
 	const ioUtil = __importStar(requireIoUtil());
 	const timers_1 = require$$6$1;
@@ -26930,7 +26930,7 @@ function requireCore () {
 		const file_command_1 = requireFileCommand();
 		const utils_1 = requireUtils$1();
 		const os = __importStar(require$$0__default);
-		const path = __importStar(require$$1__default$1);
+		const path = __importStar(path__default);
 		const oidc_utils_1 = requireOidcUtils();
 		/**
 		 * The code to exit an action
@@ -28952,7 +28952,7 @@ function requireManifest () {
 		/* eslint @typescript-eslint/no-require-imports: 0 */
 		const os = require$$0__default;
 		const cp = require$$2$2;
-		const fs = require$$1__default;
+		const fs = fs__default;
 		function _findMatch(versionSpec, stable, candidates, archFilter) {
 		    return __awaiter(this, void 0, void 0, function* () {
 		        const platFilter = os.platform();
@@ -29182,10 +29182,10 @@ function requireToolCache () {
 	const core = __importStar(requireCore());
 	const io = __importStar(requireIo());
 	const crypto = __importStar(require$$0$2);
-	const fs = __importStar(require$$1__default);
+	const fs = __importStar(fs__default);
 	const mm = __importStar(requireManifest());
 	const os = __importStar(require$$0__default);
-	const path = __importStar(require$$1__default$1);
+	const path = __importStar(path__default);
 	const httpm = __importStar(requireLib$1());
 	const semver = __importStar(requireSemver());
 	const stream$1 = __importStar(stream);
@@ -41771,7 +41771,7 @@ function requireMimeTypes () {
 		 */
 
 		var db = requireMimeDb();
-		var extname = require$$1__default$1.extname;
+		var extname = path__default.extname;
 
 		/**
 		 * Module variables.
@@ -43512,11 +43512,11 @@ function requireForm_data () {
 	hasRequiredForm_data = 1;
 	var CombinedStream = requireCombined_stream();
 	var util = require$$0$3;
-	var path = require$$1__default$1;
+	var path = path__default;
 	var http = require$$2;
 	var https = require$$3;
 	var parseUrl = require$$0$9.parse;
-	var fs = require$$1__default;
+	var fs = fs__default;
 	var Stream = stream.Stream;
 	var mime = requireMimeTypes();
 	var asynckit = requireAsynckit();
@@ -46148,7 +46148,7 @@ function requireSupportsColor () {
 	if (hasRequiredSupportsColor) return supportsColor_1;
 	hasRequiredSupportsColor = 1;
 	const os = require$$0__default;
-	const tty = require$$1$5;
+	const tty = require$$1$3;
 	const hasFlag = requireHasFlag();
 
 	const {env} = process;
@@ -46294,7 +46294,7 @@ function requireNode () {
 	if (hasRequiredNode) return node.exports;
 	hasRequiredNode = 1;
 	(function (module, exports) {
-		const tty = require$$1$5;
+		const tty = require$$1$3;
 		const util = require$$0$3;
 
 		/**
@@ -52488,8 +52488,8 @@ async function install(version) {
     if (installedVersion) {
         coreExports.info(`Already-installed Pulumi CLI is not version ${version}`);
     }
-    const tmp = require$$1.mkdtempSync('pulumi-');
-    const destination = require$$1$1.join(require$$0$1.homedir(), '.pulumi', 'bin');
+    const tmp = fs.mkdtempSync('pulumi-');
+    const destination = path.join(require$$0$1.homedir(), '.pulumi', 'bin');
     coreExports.info(`Install destination is ${destination}`);
     await ioExports.mkdirP(destination);
     coreExports.debug(`Successfully created ${destination}`);
@@ -52502,12 +52502,20 @@ async function install(version) {
     // plugins. Unix tarballs place them directly under `pulumi/`; Windows zips
     // nest them under `pulumi/bin/`. We install the whole directory so the full
     // CLI (not just `pulumi esc`) is available to later workflow steps.
-    const [extract, srcDir] = platform === 'windows' ? [toolCacheExports.extractZip, require$$1$1.join('pulumi', 'bin')] : [toolCacheExports.extractTar, 'pulumi'];
+    const [extract, srcDir] = platform === 'windows' ? [toolCacheExports.extractZip, path.join('pulumi', 'bin')] : [toolCacheExports.extractTar, 'pulumi'];
     const extractedPath = await extract(downloaded, tmp);
     coreExports.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
-    const binDir = require$$1$1.join(tmp, srcDir);
+    const binDir = path.join(tmp, srcDir);
     await ioExports.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
     coreExports.info(`Successfully moved ${binDir} to ${destination}`);
+    // Guard against a silently-empty install (e.g. an unexpected archive
+    // layout): make sure the `pulumi` binary actually landed before we add the
+    // directory to PATH, so failures surface here instead of as a confusing
+    // "command not found" in a later step.
+    const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi';
+    if (!fs.existsSync(path.join(destination, binName))) {
+        throw new Error(`Pulumi CLI install failed: ${binName} not found in ${destination} after extracting ${downloadURL}`);
+    }
     const cachedPath = await toolCacheExports.cacheDir(destination, 'pulumi', version);
     coreExports.addPath(cachedPath);
     coreExports.endGroup();
@@ -52599,7 +52607,7 @@ ${result.stderr}`);
                         // line1
                         // line2
                         // EOF
-                        require$$1.appendFileSync(envFilePath, `${to}<<PULUMIESCEOF\n${value}\nPULUMIESCEOF\n`);
+                        fs.appendFileSync(envFilePath, `${to}<<PULUMIESCEOF\n${value}\nPULUMIESCEOF\n`);
                         coreExports.info(`Injected ${to}=${from}`);
                     }
                     else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -52498,20 +52498,12 @@ async function install(version) {
     coreExports.info(`downloading ${downloadURL}`);
     const downloaded = await toolCacheExports.downloadTool(downloadURL);
     coreExports.info(`successfully downloaded ${downloadURL} to ${downloaded}`);
-    // The Pulumi CLI archive bundles the `pulumi` binary alongside its language
-    // plugins. Unix tarballs place them directly under `pulumi/`; Windows zips
-    // nest them under `pulumi/bin/`. We install the whole directory so the full
-    // CLI (not just `pulumi esc`) is available to later workflow steps.
     const [extract, srcDir] = platform === 'windows' ? [toolCacheExports.extractZip, path.join('pulumi', 'bin')] : [toolCacheExports.extractTar, 'pulumi'];
     const extractedPath = await extract(downloaded, tmp);
     coreExports.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
     const binDir = path.join(tmp, srcDir);
     await ioExports.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
     coreExports.info(`Successfully moved ${binDir} to ${destination}`);
-    // Guard against a silently-empty install (e.g. an unexpected archive
-    // layout): make sure the `pulumi` binary actually landed before we add the
-    // directory to PATH, so failures surface here instead of as a confusing
-    // "command not found" in a later step.
     const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi';
     if (!fs.existsSync(path.join(destination, binName))) {
         throw new Error(`Pulumi CLI install failed: ${binName} not found in ${destination} after extracting ${downloadURL}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esc-action",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,15 @@ async function install(version: string): Promise<void> {
     await io.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
     core.info(`Successfully moved ${binDir} to ${destination}`);
 
+    // Guard against a silently-empty install (e.g. an unexpected archive
+    // layout): make sure the `pulumi` binary actually landed before we add the
+    // directory to PATH, so failures surface here instead of as a confusing
+    // "command not found" in a later step.
+    const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi';
+    if (!fs.existsSync(path.join(destination, binName))) {
+        throw new Error(`Pulumi CLI install failed: ${binName} not found in ${destination} after extracting ${downloadURL}`);
+    }
+
     const cachedPath = await tc.cacheDir(destination, 'pulumi', version);
     core.addPath(cachedPath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,13 +125,13 @@ function getExportEnvironmentVariables(keys: string | undefined): [Record<string
 }
 
 async function getInstalledVersion(): Promise<string | undefined> {
-    const installed = await io.which('esc');
+    const installed = await io.which('pulumi');
     if (!installed) {
         return undefined;
     }
 
     // Return version without 'v' prefix
-    const { exitCode, stdout } = await exec.getExecOutput('esc', ['version']);
+    const { exitCode, stdout } = await exec.getExecOutput('pulumi', ['version']);
     if (exitCode === 0 && stdout.trim().startsWith('v')) {
         return stdout.trim().substring(1);
     }
@@ -142,39 +142,41 @@ async function getInstalledVersion(): Promise<string | undefined> {
 async function install(version: string): Promise<void> {
     const installedVersion = await getInstalledVersion();
     if (installedVersion === version) {
-        core.info('ESC CLI is already installed, skipping installation step.');
+        core.info('Pulumi CLI is already installed, skipping installation step.');
         return;
     }
 
-    core.startGroup(`Installing ESC CLI v${version}`);
+    core.startGroup(`Installing Pulumi CLI v${version}`);
     if (installedVersion) {
-        core.info(`Already-installed ESC CLI is not version ${version}`);
+        core.info(`Already-installed Pulumi CLI is not version ${version}`);
     }
 
-    const tmp = fs.mkdtempSync('esc-');
+    const tmp = fs.mkdtempSync('pulumi-');
 
-    const destination = path.join(os.homedir(), '.pulumi', 'esc', 'bin');
+    const destination = path.join(os.homedir(), '.pulumi', 'bin');
     core.info(`Install destination is ${destination}`);
 
     await io.mkdirP(destination);
     core.debug(`Successfully created ${destination}`);
 
     const [platform, arch, ext] = core.platform.platform === 'win32' ? ['windows', 'x64', 'zip'] : [core.platform.platform, core.platform.arch, 'tar.gz'];
-    const downloadURL = `https://get.pulumi.com/esc/releases/esc-v${version}-${platform}-${arch}.${ext}`;
+    const downloadURL = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${platform}-${arch}.${ext}`;
     core.info(`downloading ${downloadURL}`);
     const downloaded = await tc.downloadTool(downloadURL);
     core.info(`successfully downloaded ${downloadURL} to ${downloaded}`);
 
-    const [extract, bin, srcDir] = platform === 'windows' ? [tc.extractZip, 'esc.exe', 'bin'] : [tc.extractTar, 'esc', ''];
+    // The Pulumi CLI archive bundles the `pulumi` binary alongside its language
+    // plugins. Unix tarballs place them directly under `pulumi/`; Windows zips
+    // nest them under `pulumi/bin/`. We install the whole directory so the full
+    // CLI (not just `pulumi esc`) is available to later workflow steps.
+    const [extract, srcDir] = platform === 'windows' ? [tc.extractZip, path.join('pulumi', 'bin')] : [tc.extractTar, 'pulumi'];
     const extractedPath = await extract(downloaded, tmp);
     core.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
-    const oldPath = path.join(tmp, 'esc', srcDir, bin);
-    const newPath = path.join(destination, bin);
-    await io.cp(oldPath, newPath);
-    await io.rmRF(oldPath);
-    core.info(`Successfully moved ${oldPath} to ${newPath}`);
+    const binDir = path.join(tmp, srcDir);
+    await io.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
+    core.info(`Successfully moved ${binDir} to ${destination}`);
 
-    const cachedPath = await tc.cacheDir(destination, 'esc', version);
+    const cachedPath = await tc.cacheDir(destination, 'pulumi', version);
     core.addPath(cachedPath);
 
     core.endGroup();
@@ -198,7 +200,7 @@ async function run(): Promise<void> {
         });
 
         // Parse inputs
-        const escVersion: string = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/esc/latest-version').then(r => r.text()).then(t => t.trim());
+        const pulumiVersion: string = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/latest-version').then(r => r.text()).then(t => t.trim());
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
@@ -216,14 +218,14 @@ async function run(): Promise<void> {
         }
 
         /*
-          Install ESC CLI (either the latest or a specific version)
+          Install the Pulumi CLI (either the latest or a specific version).
 
-          The official installation script supports an optional `--version` argument to pin a release.
-          e.g. curl -fsSL https://get.pulumi.com/esc/install.sh | sh -s -- --version 0.10.0
-
-          If no version is specified, it installs the latest automatically.
+          ESC functionality is exposed through the `pulumi esc` (alias of
+          `pulumi env`) subcommands of the Pulumi CLI, so we download the CLI
+          release archive directly. If no version is specified, the latest is
+          installed automatically.
         */
-        await install(escVersion);
+        await install(pulumiVersion);
 
         if (cloudUrl) {
             // Set the ESC_CLOUD_URL environment variable if provided
@@ -242,13 +244,13 @@ async function run(): Promise<void> {
             // pointing at the file's path.
             core.startGroup(`Opening ESC environment: ${environment}`);
             const result = await exec.getExecOutput(
-                'esc',
-                ['open', environment, '--format', 'dotenv'],
+                'pulumi',
+                ['esc', 'open', environment, '--format', 'dotenv'],
                 { silent: true, ignoreReturnCode: true }
             );
 
             if (result.exitCode !== 0) {
-                throw new Error(`\`esc open\` command failed:
+                throw new Error(`\`pulumi esc open\` command failed:
 ${result.stderr}`)
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,10 +165,6 @@ async function install(version: string): Promise<void> {
     const downloaded = await tc.downloadTool(downloadURL);
     core.info(`successfully downloaded ${downloadURL} to ${downloaded}`);
 
-    // The Pulumi CLI archive bundles the `pulumi` binary alongside its language
-    // plugins. Unix tarballs place them directly under `pulumi/`; Windows zips
-    // nest them under `pulumi/bin/`. We install the whole directory so the full
-    // CLI (not just `pulumi esc`) is available to later workflow steps.
     const [extract, srcDir] = platform === 'windows' ? [tc.extractZip, path.join('pulumi', 'bin')] : [tc.extractTar, 'pulumi'];
     const extractedPath = await extract(downloaded, tmp);
     core.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
@@ -176,10 +172,6 @@ async function install(version: string): Promise<void> {
     await io.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
     core.info(`Successfully moved ${binDir} to ${destination}`);
 
-    // Guard against a silently-empty install (e.g. an unexpected archive
-    // layout): make sure the `pulumi` binary actually landed before we add the
-    // directory to PATH, so failures surface here instead of as a confusing
-    // "command not found" in a later step.
     const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi';
     if (!fs.existsSync(path.join(destination, binName))) {
         throw new Error(`Pulumi CLI install failed: ${binName} not found in ${destination} after extracting ${downloadURL}`);

--- a/src/parse-dotenv.ts
+++ b/src/parse-dotenv.ts
@@ -1,4 +1,4 @@
-// Parse the output of `esc open --format dotenv`.
+// Parse the output of `pulumi esc open --format dotenv`.
 //
 // The CLI emits one entry per line as `KEY="VALUE"`, where VALUE is the
 // Go strconv.Quote encoding of the original string. That encoding uses


### PR DESCRIPTION
## What

Switch the action from the standalone `esc` CLI to the **Pulumi CLI**, which exposes ESC functionality through the `pulumi esc` (alias of `pulumi env`) subcommands.

## Changes

- **`install()`** now downloads the Pulumi CLI release archive (`get.pulumi.com/releases/sdk/pulumi-v<version>-<platform>-<arch>.{tar.gz|zip}`) and installs the full bin directory — the `pulumi` binary plus its language plugins — to `~/.pulumi/bin`. This keeps the "CLI available for later steps" behavior intact (e.g. running `pulumi up` afterwards now works).
- Environment opening runs **`pulumi esc open <env> --format dotenv`** (was `esc open …`).
- Version detection (`pulumi version`) and the latest-version lookup (`https://www.pulumi.com/latest-version`) target the Pulumi CLI.
- **Defensive guard:** `install()` now fails fast with a clear error if the `pulumi` binary isn't present after extraction, instead of silently leaving an empty directory on `PATH` (which would surface later as a confusing "command not found").
- `cloud-url` still maps to `PULUMI_BACKEND_URL`, which the Pulumi CLI already honors — no change needed.
- Updated `action.yml`, `README.md` (incl. `@v2` → `@v3`), `.github/workflows/main.yml` (download tests now verify `pulumi version` and pin `version: '3.246.0'`), and a comment in `parse-dotenv.ts`. Rebuilt `dist/index.js`.

## Why this is a breaking change → 3.0.0

1. **PATH change** — later steps that invoked the `esc` binary will no longer find it; `pulumi` is installed instead. (Exposing the CLI on `PATH` is a documented, tested contract, not a side effect.)
2. **`version` input semantics flipped** — it used to be an ESC CLI version (e.g. `0.10.0`); it's now a Pulumi CLI version (e.g. `3.246.0`). Workflows pinning an old ESC version will fail to download.

`package.json` bumped to `3.0.0`. On release, also move the floating `v3` major tag.

> **Note on "always latest":** with no `version:` input, the action resolves the latest Pulumi CLI at **runtime** on every run, so users on `@v3` always get the newest CLI automatically — nothing to keep in sync. The only pinned version is in the CI test matrix.

## Verification

- **Unit tests** pass (`npm test`, 14/14). These cover dotenv parsing only.
- **Install path verified locally** on macOS by replaying the real download→extract→copy logic: 13 files land in the destination, the `pulumi` binary is present, and `pulumi version` returns `v3.246.0` (exit 0) — confirming both the copy and the version-detection path. No empty folder.
- **CI integration jobs** (`main.yml`) cover the install on **both `ubuntu-latest` and `windows-latest`** (the two archive layouts differ — unix binaries sit under `pulumi/`, Windows under `pulumi/bin/`), then run `pulumi version`. The env-injection jobs additionally exercise `pulumi esc open` on ubuntu.

## Test plan

- [x] Unit tests pass
- [x] Install copy + version detection verified locally (macOS)
- [x] `dist` rebuilt
- [ ] CI integration jobs verify install + injection on ubuntu/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)