### PR TITLE
Use `pulumi env` instead of the `pulumi esc` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With ESC's support for dynamic credentials and automatic secret rotation, you ca
 
 ## Functionality
 
-- If no inputs are passed, this action will download the latest version of the Pulumi CLI for direct use in later steps of the workflow. ESC functionality is provided by the `pulumi esc` subcommands.
+- If no inputs are passed, this action will download the latest version of the Pulumi CLI for direct use in later steps of the workflow. ESC functionality is provided by the `pulumi env` subcommands.
 - If a version is specified, that specific version of the Pulumi CLI will be downloaded.
 - If an `environment` is passed in as an input, the action will inject all environment variables (specifically the keys under `environmentVariables` and projected files under `files`) from the environment into the current action/workflow environment.
 - If mappings are passed via the `export-environment-variables` input - only the mapped secrets from the environment's `environmentVariables` or `files` objects will be injected into the current action.

--- a/dist/index.js
+++ b/dist/index.js
@@ -52324,7 +52324,7 @@ var axiosRetryModule = /*#__PURE__*/Object.freeze({
 	retryAfter: retryAfter
 });
 
-// Parse the output of `pulumi esc open --format dotenv`.
+// Parse the output of `pulumi env open --format dotenv`.
 //
 // The CLI emits one entry per line as `KEY="VALUE"`, where VALUE is the
 // Go strconv.Quote encoding of the original string. That encoding uses
@@ -52545,8 +52545,8 @@ async function run() {
         /*
           Install the Pulumi CLI (either the latest or a specific version).
 
-          ESC functionality is exposed through the `pulumi esc` (alias of
-          `pulumi env`) subcommands of the Pulumi CLI, so we download the CLI
+          ESC functionality is exposed through the `pulumi env`
+          subcommands of the Pulumi CLI, so we download the CLI
           release archive directly. If no version is specified, the latest is
           installed automatically.
         */
@@ -52566,9 +52566,9 @@ async function run() {
             // temporary file by the CLI and exposed here as an env var
             // pointing at the file's path.
             coreExports.startGroup(`Opening ESC environment: ${environment}`);
-            const result = await execExports.getExecOutput('pulumi', ['esc', 'open', environment, '--format', 'dotenv'], { silent: true, ignoreReturnCode: true });
+            const result = await execExports.getExecOutput('pulumi', ['env', 'open', environment, '--format', 'dotenv'], { silent: true, ignoreReturnCode: true });
             if (result.exitCode !== 0) {
-                throw new Error(`\`pulumi esc open\` command failed:
+                throw new Error(`\`pulumi env open\` command failed:
 ${result.stderr}`);
             }
             const dotenv = parseDotenv(result.stdout);

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,8 +221,8 @@ async function run(): Promise<void> {
         /*
           Install the Pulumi CLI (either the latest or a specific version).
 
-          ESC functionality is exposed through the `pulumi esc` (alias of
-          `pulumi env`) subcommands of the Pulumi CLI, so we download the CLI
+          ESC functionality is exposed through the `pulumi env`
+          subcommands of the Pulumi CLI, so we download the CLI
           release archive directly. If no version is specified, the latest is
           installed automatically.
         */
@@ -246,12 +246,12 @@ async function run(): Promise<void> {
             core.startGroup(`Opening ESC environment: ${environment}`);
             const result = await exec.getExecOutput(
                 'pulumi',
-                ['esc', 'open', environment, '--format', 'dotenv'],
+                ['env', 'open', environment, '--format', 'dotenv'],
                 { silent: true, ignoreReturnCode: true }
             );
 
             if (result.exitCode !== 0) {
-                throw new Error(`\`pulumi esc open\` command failed:
+                throw new Error(`\`pulumi env open\` command failed:
 ${result.stderr}`)
             }
 

--- a/src/parse-dotenv.ts
+++ b/src/parse-dotenv.ts
@@ -1,4 +1,4 @@
-// Parse the output of `pulumi esc open --format dotenv`.
+// Parse the output of `pulumi env open --format dotenv`.
 //
 // The CLI emits one entry per line as `KEY="VALUE"`, where VALUE is the
 // Go strconv.Quote encoding of the original string. That encoding uses


### PR DESCRIPTION
## Summary
Switches the executed Pulumi CLI command from `pulumi esc open` to `pulumi env open`, and removes all remaining references to the `pulumi esc` alias so only `pulumi env` is used/mentioned.

## Changes
- `src/index.ts` — command is now `['env', 'open', ...]`; the failure error message reads `` `pulumi env open` command failed ``; the install comment references only `pulumi env`.
- `src/parse-dotenv.ts` — comment updated to `pulumi env open`.
- `README.md` — "ESC functionality is provided by the `pulumi env` subcommands."
- `dist/index.js` — rebuilt bundle.

Left untouched (not the command/alias): the **Pulumi ESC** product name, the `esc-action` repo name, the `esc-secrets` example step id, and the `/tmp/esc-abc123` test fixture.

## Test plan
- `npm run build` succeeds.
- `npm test` — all 14 tests pass.
- `grep` confirms no remaining `pulumi esc` / `esc open` command references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)