### PR TITLE
Mask only real secrets when opening ESC environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,3 +302,60 @@ jobs:
           oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
           environment: 'pulumi/github/esc-action'
           cloud-url: https://api.pulumi-staging.io
+  # Validates the process:json-detailed masking path against an unreleased CLI built
+  # from pulumi/pulumi#23810. Repoint PULUMI_PR_REF or delete this job once the format
+  # ships in a released CLI and the version-detect fallback can be exercised normally.
+  test-process-json-detailed-branch-build:
+    runs-on: ubuntu-latest
+    env:
+      PULUMI_PR_REF: fnune/esc-open-compositional-format
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Check out pulumi/pulumi at the PR branch
+        uses: actions/checkout@v4
+        with:
+          repository: pulumi/pulumi
+          ref: ${{ env.PULUMI_PR_REF }}
+          path: pulumi-src
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: pulumi-src/pkg/go.mod
+      # A fake high version so the action's install step no-ops and uses this build.
+      - name: Build Pulumi CLI from the PR branch
+        run: |
+          mkdir -p "$HOME/.pulumi/bin"
+          (cd pulumi-src/pkg && go build -o "$HOME/.pulumi/bin/pulumi" \
+            -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=v3.999.0" \
+            ./cmd/pulumi)
+          echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
+      - name: Verify the built CLI is on PATH
+        run: pulumi version
+      - name: Authenticate with Pulumi Cloud
+        uses: pulumi/auth-actions@v1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          cloud-url: https://api.pulumi-staging.io
+      - name: Open an environment via process:json-detailed
+        id: esc
+        uses: ./
+        with:
+          version: '3.999.0'
+          environment: 'pulumi/github/esc-action'
+          cloud-url: https://api.pulumi-staging.io
+          export-environment-variables: false
+      - name: Verify injection
+        run: |
+          for var in K1 K2 K3; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: $var is not set or empty" >&2
+              exit 1
+            fi
+            echo "$var is set"
+          done
+        env:
+          K1: ${{ steps.esc.outputs.FOO }}
+          K2: ${{ steps.esc.outputs.SOME_IMPORTANT_KEY }}
+          K3: ${{ steps.esc.outputs.TEST_ENV }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -52368,6 +52368,37 @@ function parseDotenv(stdout) {
     return dotenv;
 }
 
+// The process-environment projection of an opened ESC environment: the flat set
+// of environment variables (and file-path variables) a process would see, each
+// tagged with whether ESC considers it secret.
+//
+// `pulumi env open --format process:json-detailed` emits this directly as a JSON
+// object of `{ "<name>": { "value": string, "secret": boolean } }`. Older CLIs
+// don't support that format, so we fall back to `--format dotenv` and treat
+// every value as secret (the pre-existing, over-masking behavior).
+const ProcessEnvironmentRuntype = libExports.Dictionary(libExports.Record({ value: libExports.String, secret: libExports.Boolean }), libExports.String);
+// Parses the JSON emitted by `pulumi env open --format process:json-detailed`.
+function parseProcessJsonDetailed(stdout) {
+    const parsed = JSON.parse(stdout);
+    return ProcessEnvironmentRuntype.check(parsed);
+}
+// Adapts the legacy `--format dotenv` projection to the same shape. dotenv carries
+// no secret flag, so every value is marked secret, preserving the pre-existing
+// masking behavior on older CLIs.
+function dotenvToProcessEnvironment(dotenv) {
+    const env = {};
+    for (const [key, value] of Object.entries(dotenv)) {
+        env[key] = { value, secret: true };
+    }
+    return env;
+}
+// Reports whether a `pulumi env open` failure was the CLI not recognizing the
+// format, rather than a real error (missing environment, auth failure, ...), so the
+// caller can decide whether to fall back to dotenv.
+function isUnknownFormatError(stderr) {
+    return /unknown output format|not a valid object:encoding pair|unknown output object|unknown output encoding/i.test(stderr);
+}
+
 // axios-retry v4 exports as CJS, need to access default export
 const axiosRetry = axiosRetry$1 || axiosRetryModule;
 const { exponentialDelay, isNetworkOrIdempotentRequestError } = axiosRetryModule;
@@ -52414,14 +52445,17 @@ function getOidcLoginConfig(cloudUrl) {
         organizationName: getInput('oidc-organization', 'OIDC_ORGANIZATION', true),
         requestedTokenType: getInput('oidc-requested-token-type', 'OIDC_REQUESTED_TOKEN_TYPE', true),
         scope: getInput('oidc-scope', 'OIDC_SCOPE') || undefined,
-        expiration: getNumberInput('oidc-token-expiration', 'OIDC_TOKEN_EXPIRATION') || undefined,
+        expiration: getNumberInput('oidc-token-expiration', 'OIDC_TOKEN_EXPIRATION') ||
+            undefined,
         cloudUrl: cloudUrl,
-        exportEnvironmentVariables: false,
+        exportEnvironmentVariables: false
     });
 }
 function getExportEnvironmentVariables(keys) {
     const exportAll = !keys;
-    const keysMapping = keys ? Object.fromEntries(keys.split(',').map(k => [k, k])) : {};
+    const keysMapping = keys
+        ? Object.fromEntries(keys.split(',').map(k => [k, k]))
+        : {};
     // If no value is present for keys, default to pulling mappings from keys.
     const input = getInput('export-environment-variables', 'EXPORT_ENVIRONMENT_VARIABLES');
     if (!input) {
@@ -52493,16 +52527,23 @@ async function install(version) {
     coreExports.info(`Install destination is ${destination}`);
     await ioExports.mkdirP(destination);
     coreExports.debug(`Successfully created ${destination}`);
-    const [platform, arch, ext] = coreExports.platform.platform === 'win32' ? ['windows', 'x64', 'zip'] : [coreExports.platform.platform, coreExports.platform.arch, 'tar.gz'];
+    const [platform, arch, ext] = coreExports.platform.platform === 'win32'
+        ? ['windows', 'x64', 'zip']
+        : [coreExports.platform.platform, coreExports.platform.arch, 'tar.gz'];
     const downloadURL = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${platform}-${arch}.${ext}`;
     coreExports.info(`downloading ${downloadURL}`);
     const downloaded = await toolCacheExports.downloadTool(downloadURL);
     coreExports.info(`successfully downloaded ${downloadURL} to ${downloaded}`);
-    const [extract, srcDir] = platform === 'windows' ? [toolCacheExports.extractZip, path.join('pulumi', 'bin')] : [toolCacheExports.extractTar, 'pulumi'];
+    const [extract, srcDir] = platform === 'windows'
+        ? [toolCacheExports.extractZip, path.join('pulumi', 'bin')]
+        : [toolCacheExports.extractTar, 'pulumi'];
     const extractedPath = await extract(downloaded, tmp);
     coreExports.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
     const binDir = path.join(tmp, srcDir);
-    await ioExports.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
+    await ioExports.cp(binDir, destination, {
+        recursive: true,
+        copySourceDirectory: false
+    });
     coreExports.info(`Successfully moved ${binDir} to ${destination}`);
     const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi';
     if (!fs.existsSync(path.join(destination, binName))) {
@@ -52511,6 +52552,28 @@ async function install(version) {
     const cachedPath = await toolCacheExports.cacheDir(destination, 'pulumi', version);
     coreExports.addPath(cachedPath);
     coreExports.endGroup();
+}
+async function openProcessEnvironment(environment) {
+    const open = (format) => execExports.getExecOutput('pulumi', ['env', 'open', environment, '--format', format], {
+        silent: true,
+        ignoreReturnCode: true
+    });
+    const failed = (r) => {
+        throw new Error(`\`pulumi env open\` command failed:\n${r.stderr}`);
+    };
+    // Prefer the structured projection: its per-value secret flag lets us mask only
+    // real secrets. Older CLIs lack the format; dotenv has no flag, so its fallback
+    // masks every value.
+    const detailed = await open('process:json-detailed');
+    if (detailed.exitCode === 0)
+        return parseProcessJsonDetailed(detailed.stdout);
+    if (!isUnknownFormatError(detailed.stderr))
+        failed(detailed);
+    coreExports.info('Pulumi CLI lacks `--format process:json-detailed`; falling back to dotenv (all values masked).');
+    const dotenv = await open('dotenv');
+    if (dotenv.exitCode !== 0)
+        failed(dotenv);
+    return dotenvToProcessEnvironment(parseDotenv(dotenv.stdout));
 }
 async function run() {
     try {
@@ -52524,10 +52587,13 @@ async function run() {
             },
             onRetry: (retryCount, error, requestConfig) => {
                 coreExports.info(`Retrying ${requestConfig.url} (attempt ${retryCount}/5): ${error.message}`);
-            },
+            }
         });
         // Parse inputs
-        const pulumiVersion = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/latest-version').then(r => r.text()).then(t => t.trim());
+        const pulumiVersion = getInput('version', 'VERSION') ||
+            (await fetch('https://www.pulumi.com/latest-version')
+                .then(r => r.text())
+                .then(t => t.trim()));
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
@@ -52543,13 +52609,13 @@ async function run() {
             process.env.PULUMI_ACCESS_TOKEN = accessToken;
         }
         /*
-          Install the Pulumi CLI (either the latest or a specific version).
-
-          ESC functionality is exposed through the `pulumi env`
-          subcommands of the Pulumi CLI, so we download the CLI
-          release archive directly. If no version is specified, the latest is
-          installed automatically.
-        */
+              Install the Pulumi CLI (either the latest or a specific version).
+    
+              ESC functionality is exposed through the `pulumi env`
+              subcommands of the Pulumi CLI, so we download the CLI
+              release archive directly. If no version is specified, the latest is
+              installed automatically.
+            */
         await install(pulumiVersion);
         if (cloudUrl) {
             // Set the ESC_CLOUD_URL environment variable if provided
@@ -52560,45 +52626,29 @@ async function run() {
         //
         // Check if an environment was provided. If not, skip injection.
         if (environment) {
-            // Open the environment. The dotenv format is used because it
-            // includes environment variables as well as file references --
-            // each entry in the environment's `files` is materialized to a
-            // temporary file by the CLI and exposed here as an env var
-            // pointing at the file's path.
             coreExports.startGroup(`Opening ESC environment: ${environment}`);
-            const result = await execExports.getExecOutput('pulumi', ['env', 'open', environment, '--format', 'dotenv'], { silent: true, ignoreReturnCode: true });
-            if (result.exitCode !== 0) {
-                throw new Error(`\`pulumi env open\` command failed:
-${result.stderr}`);
-            }
-            const dotenv = parseDotenv(result.stdout);
-            // Populate step outputs and mark secrets so they do not appear in logs.
-            for (const [key, value] of Object.entries(dotenv)) {
-                coreExports.setSecret(value);
+            const env = await openProcessEnvironment(environment);
+            for (const [key, { value, secret }] of Object.entries(env)) {
+                if (secret) {
+                    coreExports.setSecret(value);
+                }
                 coreExports.setOutput(key, value);
             }
-            // Calculate the final set of mappings. If allVars is true, add identity mappings for all unmapped variables;
-            // otherwise, just use the user's mappings.
             if (allVars) {
                 const mapped = new Set(Object.values(mapping));
-                for (const k of Object.keys(dotenv).filter(k => !mapped.has(k))) {
+                for (const k of Object.keys(env).filter(k => !mapped.has(k))) {
                     mapping[k] = k;
                 }
             }
-            // Export envvars.
             if (Object.keys(mapping).length != 0) {
                 const envFilePath = process.env.GITHUB_ENV;
                 if (!envFilePath) {
                     throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
                 }
                 for (const [to, from] of Object.entries(mapping)) {
-                    const value = dotenv[from];
+                    const value = env[from]?.value;
                     if (value) {
-                        // Append in multiline syntax to handle any newlines safely
-                        // e.g.: MY_ENV_VAR<<EOF
-                        // line1
-                        // line2
-                        // EOF
+                        // Heredoc syntax so values containing newlines (e.g. PEM keys) survive.
                         fs.appendFileSync(envFilePath, `${to}<<PULUMIESCEOF\n${value}\nPULUMIESCEOF\n`);
                         coreExports.info(`Injected ${to}=${from}`);
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,224 +1,306 @@
-import * as core from '@actions/core';
-import * as exec from '@actions/exec';
-import * as io from '@actions/io';
-import * as tc from '@actions/tool-cache';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import * as rt from 'runtypes';
+import * as core from '@actions/core'
+import * as exec from '@actions/exec'
+import * as io from '@actions/io'
+import * as tc from '@actions/tool-cache'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import * as rt from 'runtypes'
 import {
-    type OidcLoginConfig,
-    OidcLoginConfigRuntype,
-    ensureAccessToken,
-} from '@pulumi/actions-helpers/auth';
-import * as axiosRetryModule from 'axios-retry';
-import axios from 'axios';
-import { parseDotenv } from './parse-dotenv.js';
+  type OidcLoginConfig,
+  OidcLoginConfigRuntype,
+  ensureAccessToken
+} from '@pulumi/actions-helpers/auth'
+import * as axiosRetryModule from 'axios-retry'
+import axios from 'axios'
+import { parseDotenv } from './parse-dotenv.js'
+import {
+  dotenvToProcessEnvironment,
+  isUnknownFormatError,
+  parseProcessJsonDetailed,
+  type ProcessEnvironment
+} from './process-environment.js'
 
 // axios-retry v4 exports as CJS, need to access default export
-const axiosRetry = (axiosRetryModule as any).default || axiosRetryModule;
-const { exponentialDelay, isNetworkOrIdempotentRequestError } = axiosRetryModule;
+const axiosRetry = (axiosRetryModule as any).default || axiosRetryModule
+const { exponentialDelay, isNetworkOrIdempotentRequestError } = axiosRetryModule
 
-function getInput(name: string, envVar: string, required?: boolean): string | undefined {
-    const val = core.getInput(name) || process.env[`ESC_ACTION_${envVar}`];
-    if (!val && required) {
-        throw new Error(`Input or environment variable required and not supplied: ${name} (${envVar})`);
-    }
-    core.info(`input ${name} or ESC_ACTION_${envVar}: ${val}`);
-    return val;
+function getInput(
+  name: string,
+  envVar: string,
+  required?: boolean
+): string | undefined {
+  const val = core.getInput(name) || process.env[`ESC_ACTION_${envVar}`]
+  if (!val && required) {
+    throw new Error(
+      `Input or environment variable required and not supplied: ${name} (${envVar})`
+    )
+  }
+  core.info(`input ${name} or ESC_ACTION_${envVar}: ${val}`)
+  return val
 }
 
 function parseBooleanValue(val: string): boolean {
-    const trueValue = ['true', 'True', 'TRUE'];
-    const falseValue = ['false', 'False', 'FALSE'];
-    if (trueValue.includes(val)) {
-        return true;
-    }
-    if (falseValue.includes(val)) {
-        return false;
-    }
+  const trueValue = ['true', 'True', 'TRUE']
+  const falseValue = ['false', 'False', 'FALSE']
+  if (trueValue.includes(val)) {
+    return true
+  }
+  if (falseValue.includes(val)) {
+    return false
+  }
 
-    throw new TypeError(`Value does not meet YAML 1.2 "Core Schema" specification\n` +
-        `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+  throw new TypeError(
+    `Value does not meet YAML 1.2 "Core Schema" specification\n` +
+      `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``
+  )
 }
 
-function getBooleanInput(name: string, envVar: string, required?: boolean): boolean | undefined {
-    const val = getInput(name, envVar, required);
-    if (!val) {
-        return undefined;
-    }
-    return parseBooleanValue(val);
+function getBooleanInput(
+  name: string,
+  envVar: string,
+  required?: boolean
+): boolean | undefined {
+  const val = getInput(name, envVar, required)
+  if (!val) {
+    return undefined
+  }
+  return parseBooleanValue(val)
 }
 
-function getNumberInput(name: string, envVar: string, required?: boolean): number | undefined {
-    const val = getInput(name, envVar, required);
-    if (!val) {
-        return undefined;
-    }
-    const parsedVal = Number(val);
-    if (Number.isNaN(parsedVal)) {
-        throw new Error('Input was not a number');
-    }
-    return parsedVal || undefined;
+function getNumberInput(
+  name: string,
+  envVar: string,
+  required?: boolean
+): number | undefined {
+  const val = getInput(name, envVar, required)
+  if (!val) {
+    return undefined
+  }
+  const parsedVal = Number(val)
+  if (Number.isNaN(parsedVal)) {
+    throw new Error('Input was not a number')
+  }
+  return parsedVal || undefined
 }
 
 function getOidcLoginConfig(cloudUrl: string): rt.Result<OidcLoginConfig> {
-    return OidcLoginConfigRuntype.validate({
-        organizationName: getInput('oidc-organization', 'OIDC_ORGANIZATION', true)!,
-        requestedTokenType: getInput('oidc-requested-token-type', 'OIDC_REQUESTED_TOKEN_TYPE', true)!,
-        scope: getInput('oidc-scope', 'OIDC_SCOPE') || undefined,
-        expiration: getNumberInput('oidc-token-expiration', 'OIDC_TOKEN_EXPIRATION') || undefined,
-        cloudUrl: cloudUrl || 'https://api.pulumi.com',
-        exportEnvironmentVariables: false,
-    });
+  return OidcLoginConfigRuntype.validate({
+    organizationName: getInput('oidc-organization', 'OIDC_ORGANIZATION', true)!,
+    requestedTokenType: getInput(
+      'oidc-requested-token-type',
+      'OIDC_REQUESTED_TOKEN_TYPE',
+      true
+    )!,
+    scope: getInput('oidc-scope', 'OIDC_SCOPE') || undefined,
+    expiration:
+      getNumberInput('oidc-token-expiration', 'OIDC_TOKEN_EXPIRATION') ||
+      undefined,
+    cloudUrl: cloudUrl || 'https://api.pulumi.com',
+    exportEnvironmentVariables: false
+  })
 }
 
-function getExportEnvironmentVariables(keys: string | undefined): [Record<string, string>, boolean] {
-    const exportAll = !keys;
-    const keysMapping = keys ? Object.fromEntries(keys.split(',').map(k => [k, k])) : {};
+function getExportEnvironmentVariables(
+  keys: string | undefined
+): [Record<string, string>, boolean] {
+  const exportAll = !keys
+  const keysMapping = keys
+    ? Object.fromEntries(keys.split(',').map(k => [k, k]))
+    : {}
 
-    // If no value is present for keys, default to pulling mappings from keys.
-    const input = getInput('export-environment-variables', 'EXPORT_ENVIRONMENT_VARIABLES');
-    if (!input) {
-        return [keysMapping, exportAll]
+  // If no value is present for keys, default to pulling mappings from keys.
+  const input = getInput(
+    'export-environment-variables',
+    'EXPORT_ENVIRONMENT_VARIABLES'
+  )
+  if (!input) {
+    return [keysMapping, exportAll]
+  }
+
+  // If the value is a boolean true or false, return it with the mappings from keys.
+  try {
+    const exportAny = parseBooleanValue(input)
+    return !exportAny ? [{}, false] : [keysMapping, exportAll]
+  } catch {}
+
+  // Otherwise, parse the value as a list of [FOO=]BAR key-value pairs, where FOO is the name of the envvar to set and
+  // BAR is the name of the variable to use as the value. If FOO is omitted, BAR is also used as the name of the
+  // envvar to set. If BAR is '*', then all unmapped variables are implicitly mapped to themselves.
+  //
+  // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
+  // this environment:
+  //
+  //   GITHUB_TOKEN=PULUMI_BOT_TOKEN
+  //   AWS_KEY_ID=AWS_KEY_ID
+  //   AWS_SECRET_KEY=AWS_SECRET_KEY
+  //   AWS_SESSION_TOKEN=AWS_SESSION_TOKEN
+  //
+  // If the source ESC env also contained other environment variables, they would not be exported. All non-mapped variables
+  // can be exported with the identity mapping by including '*' as a key. For example, 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,*`
+  // would also export the environment above assuming no other envvars exist in the ESC environment.
+
+  let all = false
+  const mappings: Record<string, string> = {}
+  for (const mapping of input.split(',').map(v => v.trim())) {
+    if (mapping === '*') {
+      all = true
+      continue
     }
 
-    // If the value is a boolean true or false, return it with the mappings from keys.
-    try {
-        const exportAny = parseBooleanValue(input);
-        return !exportAny ? [{}, false] : [keysMapping, exportAll];
-    } catch { }
-
-    // Otherwise, parse the value as a list of [FOO=]BAR key-value pairs, where FOO is the name of the envvar to set and
-    // BAR is the name of the variable to use as the value. If FOO is omitted, BAR is also used as the name of the
-    // envvar to set. If BAR is '*', then all unmapped variables are implicitly mapped to themselves.
-    //
-    // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
-    // this environment:
-    //
-    //   GITHUB_TOKEN=PULUMI_BOT_TOKEN
-    //   AWS_KEY_ID=AWS_KEY_ID
-    //   AWS_SECRET_KEY=AWS_SECRET_KEY
-    //   AWS_SESSION_TOKEN=AWS_SESSION_TOKEN
-    //
-    // If the source ESC env also contained other environment variables, they would not be exported. All non-mapped variables
-    // can be exported with the identity mapping by including '*' as a key. For example, 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,*`
-    // would also export the environment above assuming no other envvars exist in the ESC environment.
-
-    let all = false;
-    const mappings: Record<string, string> = {};
-    for (const mapping of input.split(',').map(v => v.trim())) {
-        if (mapping === '*') {
-            all = true;
-            continue;
-        }
-
-        const eq = mapping.indexOf('=');
-        if (eq === -1) {
-            mappings[mapping] = mapping;
-        } else {
-            const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)];
-            mappings[to] = from;
-        }
+    const eq = mapping.indexOf('=')
+    if (eq === -1) {
+      mappings[mapping] = mapping
+    } else {
+      const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)]
+      mappings[to] = from
     }
-    return [mappings, all];
+  }
+  return [mappings, all]
 }
 
 async function getInstalledVersion(): Promise<string | undefined> {
-    const installed = await io.which('pulumi');
-    if (!installed) {
-        return undefined;
-    }
+  const installed = await io.which('pulumi')
+  if (!installed) {
+    return undefined
+  }
 
-    // Return version without 'v' prefix
-    const { exitCode, stdout } = await exec.getExecOutput('pulumi', ['version']);
-    if (exitCode === 0 && stdout.trim().startsWith('v')) {
-        return stdout.trim().substring(1);
-    }
+  // Return version without 'v' prefix
+  const { exitCode, stdout } = await exec.getExecOutput('pulumi', ['version'])
+  if (exitCode === 0 && stdout.trim().startsWith('v')) {
+    return stdout.trim().substring(1)
+  }
 
-    return undefined;
+  return undefined
 }
 
 async function install(version: string): Promise<void> {
-    const installedVersion = await getInstalledVersion();
-    if (installedVersion === version) {
-        core.info('Pulumi CLI is already installed, skipping installation step.');
-        return;
-    }
+  const installedVersion = await getInstalledVersion()
+  if (installedVersion === version) {
+    core.info('Pulumi CLI is already installed, skipping installation step.')
+    return
+  }
 
-    core.startGroup(`Installing Pulumi CLI v${version}`);
-    if (installedVersion) {
-        core.info(`Already-installed Pulumi CLI is not version ${version}`);
-    }
+  core.startGroup(`Installing Pulumi CLI v${version}`)
+  if (installedVersion) {
+    core.info(`Already-installed Pulumi CLI is not version ${version}`)
+  }
 
-    const tmp = fs.mkdtempSync('pulumi-');
+  const tmp = fs.mkdtempSync('pulumi-')
 
-    const destination = path.join(os.homedir(), '.pulumi', 'bin');
-    core.info(`Install destination is ${destination}`);
+  const destination = path.join(os.homedir(), '.pulumi', 'bin')
+  core.info(`Install destination is ${destination}`)
 
-    await io.mkdirP(destination);
-    core.debug(`Successfully created ${destination}`);
+  await io.mkdirP(destination)
+  core.debug(`Successfully created ${destination}`)
 
-    const [platform, arch, ext] = core.platform.platform === 'win32' ? ['windows', 'x64', 'zip'] : [core.platform.platform, core.platform.arch, 'tar.gz'];
-    const downloadURL = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${platform}-${arch}.${ext}`;
-    core.info(`downloading ${downloadURL}`);
-    const downloaded = await tc.downloadTool(downloadURL);
-    core.info(`successfully downloaded ${downloadURL} to ${downloaded}`);
+  const [platform, arch, ext] =
+    core.platform.platform === 'win32'
+      ? ['windows', 'x64', 'zip']
+      : [core.platform.platform, core.platform.arch, 'tar.gz']
+  const downloadURL = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${platform}-${arch}.${ext}`
+  core.info(`downloading ${downloadURL}`)
+  const downloaded = await tc.downloadTool(downloadURL)
+  core.info(`successfully downloaded ${downloadURL} to ${downloaded}`)
 
-    const [extract, srcDir] = platform === 'windows' ? [tc.extractZip, path.join('pulumi', 'bin')] : [tc.extractTar, 'pulumi'];
-    const extractedPath = await extract(downloaded, tmp);
-    core.info(`Successfully extracted ${downloaded} to ${extractedPath}`);
-    const binDir = path.join(tmp, srcDir);
-    await io.cp(binDir, destination, { recursive: true, copySourceDirectory: false });
-    core.info(`Successfully moved ${binDir} to ${destination}`);
+  const [extract, srcDir] =
+    platform === 'windows'
+      ? [tc.extractZip, path.join('pulumi', 'bin')]
+      : [tc.extractTar, 'pulumi']
+  const extractedPath = await extract(downloaded, tmp)
+  core.info(`Successfully extracted ${downloaded} to ${extractedPath}`)
+  const binDir = path.join(tmp, srcDir)
+  await io.cp(binDir, destination, {
+    recursive: true,
+    copySourceDirectory: false
+  })
+  core.info(`Successfully moved ${binDir} to ${destination}`)
 
-    const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi';
-    if (!fs.existsSync(path.join(destination, binName))) {
-        throw new Error(`Pulumi CLI install failed: ${binName} not found in ${destination} after extracting ${downloadURL}`);
-    }
+  const binName = platform === 'windows' ? 'pulumi.exe' : 'pulumi'
+  if (!fs.existsSync(path.join(destination, binName))) {
+    throw new Error(
+      `Pulumi CLI install failed: ${binName} not found in ${destination} after extracting ${downloadURL}`
+    )
+  }
 
-    const cachedPath = await tc.cacheDir(destination, 'pulumi', version);
-    core.addPath(cachedPath);
+  const cachedPath = await tc.cacheDir(destination, 'pulumi', version)
+  core.addPath(cachedPath)
 
-    core.endGroup();
+  core.endGroup()
+}
+
+async function openProcessEnvironment(
+  environment: string
+): Promise<ProcessEnvironment> {
+  const open = (format: string) =>
+    exec.getExecOutput(
+      'pulumi',
+      ['env', 'open', environment, '--format', format],
+      {
+        silent: true,
+        ignoreReturnCode: true
+      }
+    )
+  const failed = (r: { stderr: string }): never => {
+    throw new Error(`\`pulumi env open\` command failed:\n${r.stderr}`)
+  }
+
+  // Prefer the structured projection: its per-value secret flag lets us mask only
+  // real secrets. Older CLIs lack the format; dotenv has no flag, so its fallback
+  // masks every value.
+  const detailed = await open('process:json-detailed')
+  if (detailed.exitCode === 0) return parseProcessJsonDetailed(detailed.stdout)
+  if (!isUnknownFormatError(detailed.stderr)) failed(detailed)
+
+  core.info(
+    'Pulumi CLI lacks `--format process:json-detailed`; falling back to dotenv (all values masked).'
+  )
+  const dotenv = await open('dotenv')
+  if (dotenv.exitCode !== 0) failed(dotenv)
+  return dotenvToProcessEnvironment(parseDotenv(dotenv.stdout))
 }
 
 async function run(): Promise<void> {
-    try {
-        // Configure axios with automatic retry for network errors
-        axiosRetry(axios, {
-            retries: 5,
-            retryDelay: exponentialDelay,
-            retryCondition: (error: any) => {
-                // Retry on network errors (no response) and idempotent request errors
-                return isNetworkOrIdempotentRequestError(error);
-            },
-            onRetry: (retryCount: number, error: any, requestConfig: any) => {
-                core.info(
-                    `Retrying ${requestConfig.url} (attempt ${retryCount}/5): ${error.message}`
-                );
-            },
-        });
+  try {
+    // Configure axios with automatic retry for network errors
+    axiosRetry(axios, {
+      retries: 5,
+      retryDelay: exponentialDelay,
+      retryCondition: (error: any) => {
+        // Retry on network errors (no response) and idempotent request errors
+        return isNetworkOrIdempotentRequestError(error)
+      },
+      onRetry: (retryCount: number, error: any, requestConfig: any) => {
+        core.info(
+          `Retrying ${requestConfig.url} (attempt ${retryCount}/5): ${error.message}`
+        )
+      }
+    })
 
-        // Parse inputs
-        const pulumiVersion: string = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/latest-version').then(r => r.text()).then(t => t.trim());
-        const environment = getInput('environment', 'ENVIRONMENT');
-        const keys = getInput('keys', 'KEYS');
-        const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';
-        const [mapping, allVars] = getExportEnvironmentVariables(keys);
+    // Parse inputs
+    const pulumiVersion: string =
+      getInput('version', 'VERSION') ||
+      (await fetch('https://www.pulumi.com/latest-version')
+        .then(r => r.text())
+        .then(t => t.trim()))
+    const environment = getInput('environment', 'ENVIRONMENT')
+    const keys = getInput('keys', 'KEYS')
+    const cloudUrl =
+      getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com'
+    const [mapping, allVars] = getExportEnvironmentVariables(keys)
 
-        const useOidcAuth = getBooleanInput('oidc-auth', 'OIDC_AUTH');
-        if (useOidcAuth) {
-            const oidcConfig = getOidcLoginConfig(cloudUrl);
-            if (!oidcConfig.success) {
-                throw new Error('Invalid OIDC configuration');
-            }
-            const accessToken = await ensureAccessToken(oidcConfig.value);
-            core.setSecret(accessToken);
-            process.env.PULUMI_ACCESS_TOKEN = accessToken;
-        }
+    const useOidcAuth = getBooleanInput('oidc-auth', 'OIDC_AUTH')
+    if (useOidcAuth) {
+      const oidcConfig = getOidcLoginConfig(cloudUrl)
+      if (!oidcConfig.success) {
+        throw new Error('Invalid OIDC configuration')
+      }
+      const accessToken = await ensureAccessToken(oidcConfig.value)
+      core.setSecret(accessToken)
+      process.env.PULUMI_ACCESS_TOKEN = accessToken
+    }
 
-        /*
+    /*
           Install the Pulumi CLI (either the latest or a specific version).
 
           ESC functionality is exposed through the `pulumi env`
@@ -226,85 +308,72 @@ async function run(): Promise<void> {
           release archive directly. If no version is specified, the latest is
           installed automatically.
         */
-        await install(pulumiVersion);
+    await install(pulumiVersion)
 
-        if (cloudUrl) {
-            // Set the ESC_CLOUD_URL environment variable if provided
-            core.info(`Setting PULUMI_BACKEND_URL to ${cloudUrl}`);
-            process.env.PULUMI_BACKEND_URL = cloudUrl;
-        }
-
-        // Inject environment variables if requested
-        //
-        // Check if an environment was provided. If not, skip injection.
-        if (environment) {
-            // Open the environment. The dotenv format is used because it
-            // includes environment variables as well as file references --
-            // each entry in the environment's `files` is materialized to a
-            // temporary file by the CLI and exposed here as an env var
-            // pointing at the file's path.
-            core.startGroup(`Opening ESC environment: ${environment}`);
-            const result = await exec.getExecOutput(
-                'pulumi',
-                ['env', 'open', environment, '--format', 'dotenv'],
-                { silent: true, ignoreReturnCode: true }
-            );
-
-            if (result.exitCode !== 0) {
-                throw new Error(`\`pulumi env open\` command failed:
-${result.stderr}`)
-            }
-
-            const dotenv = parseDotenv(result.stdout);
-
-            // Populate step outputs and mark secrets so they do not appear in logs.
-            for (const [key, value] of Object.entries(dotenv)) {
-                core.setSecret(value);
-                core.setOutput(key, value);
-            }
-
-            // Calculate the final set of mappings. If allVars is true, add identity mappings for all unmapped variables;
-            // otherwise, just use the user's mappings.
-			if (allVars) {
-				const mapped = new Set(Object.values(mapping));
-				for (const k of Object.keys(dotenv).filter(k => !mapped.has(k))) {
-					mapping[k] = k;
-				}
-			}
-
-            // Export envvars.
-            if (Object.keys(mapping).length != 0) {
-                const envFilePath = process.env.GITHUB_ENV;
-                if (!envFilePath) {
-                    throw new Error('GITHUB_ENV is not defined. Cannot append environment variables.');
-                }
-
-                for (const [to, from] of Object.entries(mapping)) {
-                    const value = dotenv[from];
-                    if (value) {
-                        // Append in multiline syntax to handle any newlines safely
-                        // e.g.: MY_ENV_VAR<<EOF
-                        // line1
-                        // line2
-                        // EOF
-                        fs.appendFileSync(envFilePath, `${to}<<PULUMIESCEOF\n${value}\nPULUMIESCEOF\n`);
-                        core.info(`Injected ${to}=${from}`);
-                    } else {
-                        core.warning(`No value found for ${to}=environmentVariables.${from}`);
-                    }
-                }
-                core.info(`Injected ${Object.keys(mapping).length} environment variables`);
-            }
-
-            core.endGroup();
-        }
-    } catch (error) {
-        if (error instanceof Error) {
-            core.setFailed(error.message);
-        } else {
-            core.setFailed(String(error));
-        }
+    if (cloudUrl) {
+      // Set the ESC_CLOUD_URL environment variable if provided
+      core.info(`Setting PULUMI_BACKEND_URL to ${cloudUrl}`)
+      process.env.PULUMI_BACKEND_URL = cloudUrl
     }
+
+    // Inject environment variables if requested
+    //
+    // Check if an environment was provided. If not, skip injection.
+    if (environment) {
+      core.startGroup(`Opening ESC environment: ${environment}`)
+      const env = await openProcessEnvironment(environment)
+
+      for (const [key, { value, secret }] of Object.entries(env)) {
+        if (secret) {
+          core.setSecret(value)
+        }
+        core.setOutput(key, value)
+      }
+
+      if (allVars) {
+        const mapped = new Set(Object.values(mapping))
+        for (const k of Object.keys(env).filter(k => !mapped.has(k))) {
+          mapping[k] = k
+        }
+      }
+
+      if (Object.keys(mapping).length != 0) {
+        const envFilePath = process.env.GITHUB_ENV
+        if (!envFilePath) {
+          throw new Error(
+            'GITHUB_ENV is not defined. Cannot append environment variables.'
+          )
+        }
+
+        for (const [to, from] of Object.entries(mapping)) {
+          const value = env[from]?.value
+          if (value) {
+            // Heredoc syntax so values containing newlines (e.g. PEM keys) survive.
+            fs.appendFileSync(
+              envFilePath,
+              `${to}<<PULUMIESCEOF\n${value}\nPULUMIESCEOF\n`
+            )
+            core.info(`Injected ${to}=${from}`)
+          } else {
+            core.warning(
+              `No value found for ${to}=environmentVariables.${from}`
+            )
+          }
+        }
+        core.info(
+          `Injected ${Object.keys(mapping).length} environment variables`
+        )
+      }
+
+      core.endGroup()
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(error.message)
+    } else {
+      core.setFailed(String(error))
+    }
+  }
 }
 
-run();
+run()

--- a/src/process-environment.test.ts
+++ b/src/process-environment.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test'
+import * as assert from 'node:assert/strict'
+import {
+  dotenvToProcessEnvironment,
+  isUnknownFormatError,
+  parseProcessJsonDetailed
+} from './process-environment.js'
+
+test('parses process:json-detailed with secret flags', () => {
+  const stdout = JSON.stringify({
+    FOO: { value: 'bar', secret: false },
+    SECRET: { value: 'shh', secret: true },
+    NUM_FILE: { value: '/tmp/esc-123', secret: false }
+  })
+
+  const env = parseProcessJsonDetailed(stdout)
+
+  assert.deepEqual(env.FOO, { value: 'bar', secret: false })
+  assert.deepEqual(env.SECRET, { value: 'shh', secret: true })
+  assert.deepEqual(env.NUM_FILE, { value: '/tmp/esc-123', secret: false })
+})
+
+test('rejects malformed process:json-detailed', () => {
+  assert.throws(() => parseProcessJsonDetailed('{"FOO":"bar"}'))
+  assert.throws(() => parseProcessJsonDetailed('not json'))
+})
+
+test('dotenv fallback marks every value secret', () => {
+  const env = dotenvToProcessEnvironment({ FOO: 'bar', SECRET: 'shh' })
+
+  assert.deepEqual(env.FOO, { value: 'bar', secret: true })
+  assert.deepEqual(env.SECRET, { value: 'shh', secret: true })
+})
+
+test('detects unknown-format errors from older CLIs', () => {
+  assert.ok(
+    isUnknownFormatError('error: unknown output format "process:json-detailed"')
+  )
+  assert.ok(
+    isUnknownFormatError(
+      'output format "process:json-detailed" is not a valid object:encoding pair'
+    )
+  )
+  assert.ok(!isUnknownFormatError('error: environment "acme/dev" not found'))
+  assert.ok(!isUnknownFormatError('error: not logged in'))
+})

--- a/src/process-environment.ts
+++ b/src/process-environment.ts
@@ -1,0 +1,46 @@
+// The process-environment projection of an opened ESC environment: the flat set
+// of environment variables (and file-path variables) a process would see, each
+// tagged with whether ESC considers it secret.
+//
+// `pulumi env open --format process:json-detailed` emits this directly as a JSON
+// object of `{ "<name>": { "value": string, "secret": boolean } }`. Older CLIs
+// don't support that format, so we fall back to `--format dotenv` and treat
+// every value as secret (the pre-existing, over-masking behavior).
+
+import * as rt from 'runtypes'
+
+export type ProcessEnvironmentEntry = { value: string; secret: boolean }
+export type ProcessEnvironment = Record<string, ProcessEnvironmentEntry>
+
+const ProcessEnvironmentRuntype = rt.Dictionary(
+  rt.Record({ value: rt.String, secret: rt.Boolean }),
+  rt.String
+)
+
+// Parses the JSON emitted by `pulumi env open --format process:json-detailed`.
+export function parseProcessJsonDetailed(stdout: string): ProcessEnvironment {
+  const parsed = JSON.parse(stdout)
+  return ProcessEnvironmentRuntype.check(parsed)
+}
+
+// Adapts the legacy `--format dotenv` projection to the same shape. dotenv carries
+// no secret flag, so every value is marked secret, preserving the pre-existing
+// masking behavior on older CLIs.
+export function dotenvToProcessEnvironment(
+  dotenv: Record<string, string>
+): ProcessEnvironment {
+  const env: ProcessEnvironment = {}
+  for (const [key, value] of Object.entries(dotenv)) {
+    env[key] = { value, secret: true }
+  }
+  return env
+}
+
+// Reports whether a `pulumi env open` failure was the CLI not recognizing the
+// format, rather than a real error (missing environment, auth failure, ...), so the
+// caller can decide whether to fall back to dotenv.
+export function isUnknownFormatError(stderr: string): boolean {
+  return /unknown output format|not a valid object:encoding pair|unknown output object|unknown output encoding/i.test(
+    stderr
+  )
+}


### PR DESCRIPTION
The action opens the environment with `--format dotenv`, which has no per-value secret flag, so it masks every value with `core.setSecret` -- including plaintext config -- which over-masks unrelated log output.

Use `pulumi env open --format process:json-detailed` when available: it returns the process-environment as structured JSON with a per-value `secret` flag, so only values ESC marks secret are masked. Older CLIs that lack the format fall back to the existing dotenv path (all values masked), detected by trying the format and catching the unknown-format error -- no CLI version pin, since the format is not yet in a released CLI.

The structured format is added in pulumi/pulumi#23810.

Fixes #24
Relates to #44

## Test plan

- Automated
  - `src/process-environment.test.ts`: parsing `process:json-detailed`, dotenv fallback marking every value secret, unknown-format detection
- Integration (`.github/workflows/main.yml`)
  - `test-process-json-detailed-branch-build`: builds the CLI from pulumi/pulumi#23810, runs the action against the staging environment, verifies injection through the new path
