### PR TITLE
Mark dist/ as generated for GitHub linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** linguist-generated=true


### PR DESCRIPTION
## Description

The `dist/` directory holds the ncc-bundled action output (`dist/index.js`, ~52k lines). This adds a `.gitattributes` marking `dist/**` as `linguist-generated=true` so GitHub:

- collapses it by default in PR diffs
- excludes it from the repository's language statistics

## Checklist

- [x] No functional changes; tooling/metadata only