### PR TITLE
fix: allow newline-separated entries in export-environment-variables/keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ For case (3), each _export mapping_ takes one of the following three forms:
 2. `SECRET`, which maps the ESC secret named `SECRET` to the environment variable `SECRET` (equivalent to `SECRET=SECRET`)
 3. `*`, which adds identity mappings for any unmapped secrets
 
+Mappings may be separated by commas, newlines, or both. This means the value can be given either as
+a single-line comma-separated list (`SOME_KEY,ANOTHER_KEY,LAST_KEY`) or as a YAML block scalar with
+one mapping per line, e.g.:
+
+```yaml
+export-environment-variables: |
+  SOME_KEY
+  ANOTHER_KEY
+  LAST_KEY
+```
+
 ### `oidc-auth` (`ESC_ACTION_OIDC_AUTH`)
 
 **Optional** When this input is `true`, the ESC action will exchange the GitHub workflow's OIDC token for a Pulumi Access Token. This token is not available to other steps. Requires `id-token: write` permission.

--- a/dist/index.js
+++ b/dist/index.js
@@ -52368,6 +52368,66 @@ function parseDotenv(stdout) {
     return dotenv;
 }
 
+// Parse the `keys` and `export-environment-variables` action inputs.
+//
+// Both inputs accept a list of entries. Historically entries could only be
+// separated by commas (`FOO,BAR,BAZ`), but GitHub Actions YAML also commonly
+// supplies list-like values as a block scalar, one entry per line:
+//
+//   export-environment-variables: |
+//     JIRA_API_TOKEN
+//     JIRA_CLOUD_ID
+//     JIRA_WORKSPACE_ID
+//
+// If entries are only split on `,`, a newline-separated block collapses into
+// a single bogus entry containing embedded newlines (since there's no comma
+// to split on), which then fails to match any real key in the opened
+// environment. To support both styles -- and any mix of the two -- entries
+// are split on commas and/or newlines, with surrounding whitespace trimmed
+// and empty entries discarded.
+const SEPARATOR = /[,\n]/;
+function splitEntries(input) {
+    return input
+        .split(SEPARATOR)
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0);
+}
+// Parses the deprecated `keys` input: a list of key names to inject as-is.
+function parseKeysList(keys) {
+    return splitEntries(keys);
+}
+// Parses the `export-environment-variables` input (once it's been
+// determined not to be a boolean) into a mapping of destination envvar name
+// to source ESC environment variable name, plus whether unmapped variables
+// should also be exported (triggered by a bare `*` entry).
+//
+// Each entry takes one of the following three forms:
+//
+// 1. `FOO=BAR`, which maps the ESC secret named `BAR` to the environment
+//    variable `FOO`
+// 2. `BAR`, which maps the ESC secret named `BAR` to the environment
+//    variable `BAR` (equivalent to `BAR=BAR`)
+// 3. `*`, which adds identity mappings for any unmapped secrets
+function parseExportMappings(input) {
+    let all = false;
+    const mappings = {};
+    for (const entry of splitEntries(input)) {
+        if (entry === '*') {
+            all = true;
+            continue;
+        }
+        const eq = entry.indexOf('=');
+        if (eq === -1) {
+            mappings[entry] = entry;
+        }
+        else {
+            const [to, from] = [entry.slice(0, eq), entry.slice(eq + 1)];
+            mappings[to] = from;
+        }
+    }
+    return [mappings, all];
+}
+
 // axios-retry v4 exports as CJS, need to access default export
 const axiosRetry = axiosRetry$1 || axiosRetryModule;
 const { exponentialDelay, isNetworkOrIdempotentRequestError } = axiosRetryModule;
@@ -52421,7 +52481,9 @@ function getOidcLoginConfig(cloudUrl) {
 }
 function getExportEnvironmentVariables(keys) {
     const exportAll = !keys;
-    const keysMapping = keys ? Object.fromEntries(keys.split(',').map(k => [k, k])) : {};
+    const keysMapping = keys
+        ? Object.fromEntries(parseKeysList(keys).map(k => [k, k]))
+        : {};
     // If no value is present for keys, default to pulling mappings from keys.
     const input = getInput('export-environment-variables', 'EXPORT_ENVIRONMENT_VARIABLES');
     if (!input) {
@@ -52437,6 +52499,9 @@ function getExportEnvironmentVariables(keys) {
     // BAR is the name of the variable to use as the value. If FOO is omitted, BAR is also used as the name of the
     // envvar to set. If BAR is '*', then all unmapped variables are implicitly mapped to themselves.
     //
+    // Entries may be separated by commas, newlines, or both -- this allows the input to be provided either as a
+    // single-line comma-separated list or as a YAML block scalar with one entry per line (or any mix thereof).
+    //
     // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
     // this environment:
     //
@@ -52448,23 +52513,7 @@ function getExportEnvironmentVariables(keys) {
     // If the source ESC env also contained other environment variables, they would not be exported. All non-mapped variables
     // can be exported with the identity mapping by including '*' as a key. For example, 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,*`
     // would also export the environment above assuming no other envvars exist in the ESC environment.
-    let all = false;
-    const mappings = {};
-    for (const mapping of input.split(',').map(v => v.trim())) {
-        if (mapping === '*') {
-            all = true;
-            continue;
-        }
-        const eq = mapping.indexOf('=');
-        if (eq === -1) {
-            mappings[mapping] = mapping;
-        }
-        else {
-            const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)];
-            mappings[to] = from;
-        }
-    }
-    return [mappings, all];
+    return parseExportMappings(input);
 }
 async function getInstalledVersion() {
     const installed = await ioExports.which('pulumi');

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 import * as axiosRetryModule from 'axios-retry';
 import axios from 'axios';
 import { parseDotenv } from './parse-dotenv.js';
+import { parseKeysList, parseExportMappings } from './parse-mapping.js';
 
 // axios-retry v4 exports as CJS, need to access default export
 const axiosRetry = (axiosRetryModule as any).default || axiosRetryModule;
@@ -75,7 +76,9 @@ function getOidcLoginConfig(cloudUrl: string): rt.Result<OidcLoginConfig> {
 
 function getExportEnvironmentVariables(keys: string | undefined): [Record<string, string>, boolean] {
     const exportAll = !keys;
-    const keysMapping = keys ? Object.fromEntries(keys.split(',').map(k => [k, k])) : {};
+    const keysMapping = keys
+        ? Object.fromEntries(parseKeysList(keys).map(k => [k, k]))
+        : {};
 
     // If no value is present for keys, default to pulling mappings from keys.
     const input = getInput('export-environment-variables', 'EXPORT_ENVIRONMENT_VARIABLES');
@@ -93,6 +96,9 @@ function getExportEnvironmentVariables(keys: string | undefined): [Record<string
     // BAR is the name of the variable to use as the value. If FOO is omitted, BAR is also used as the name of the
     // envvar to set. If BAR is '*', then all unmapped variables are implicitly mapped to themselves.
     //
+    // Entries may be separated by commas, newlines, or both -- this allows the input to be provided either as a
+    // single-line comma-separated list or as a YAML block scalar with one entry per line (or any mix thereof).
+    //
     // For example, the value 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY,AWS_SESSION_TOKEN' will export
     // this environment:
     //
@@ -104,24 +110,7 @@ function getExportEnvironmentVariables(keys: string | undefined): [Record<string
     // If the source ESC env also contained other environment variables, they would not be exported. All non-mapped variables
     // can be exported with the identity mapping by including '*' as a key. For example, 'GITHUB_TOKEN=PULUMI_BOT_TOKEN,*`
     // would also export the environment above assuming no other envvars exist in the ESC environment.
-
-    let all = false;
-    const mappings: Record<string, string> = {};
-    for (const mapping of input.split(',').map(v => v.trim())) {
-        if (mapping === '*') {
-            all = true;
-            continue;
-        }
-
-        const eq = mapping.indexOf('=');
-        if (eq === -1) {
-            mappings[mapping] = mapping;
-        } else {
-            const [to, from] = [mapping.slice(0, eq), mapping.slice(eq + 1)];
-            mappings[to] = from;
-        }
-    }
-    return [mappings, all];
+    return parseExportMappings(input);
 }
 
 async function getInstalledVersion(): Promise<string | undefined> {

--- a/src/parse-mapping.test.ts
+++ b/src/parse-mapping.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { parseKeysList, parseExportMappings } from './parse-mapping.js';
+
+test('parseKeysList splits a comma-separated list', () => {
+    assert.deepEqual(parseKeysList('A,B,C'), ['A', 'B', 'C']);
+});
+
+test('parseKeysList splits a newline-separated list (YAML block scalar)', () => {
+    // This mirrors the customer-reported bug: `export-environment-variables`
+    // (and, historically, `keys`) supplied as a YAML block scalar joins
+    // entries with `\n` rather than `,`.
+    assert.deepEqual(parseKeysList('A\nB\nC'), ['A', 'B', 'C']);
+});
+
+test('parseKeysList trims whitespace and drops empty entries', () => {
+    assert.deepEqual(parseKeysList(' A \n\n B ,C\n'), ['A', 'B', 'C']);
+});
+
+test('parseExportMappings supports comma-separated identity and renamed entries', () => {
+    const [mappings, all] = parseExportMappings('GITHUB_TOKEN=PULUMI_BOT_TOKEN,AWS_KEY_ID,AWS_SECRET_KEY');
+    assert.deepEqual(mappings, {
+        GITHUB_TOKEN: 'PULUMI_BOT_TOKEN',
+        AWS_KEY_ID: 'AWS_KEY_ID',
+        AWS_SECRET_KEY: 'AWS_SECRET_KEY',
+    });
+    assert.equal(all, false);
+});
+
+test('parseExportMappings supports newline-separated entries (regression for reported bug)', () => {
+    // Reported case: a YAML block scalar like
+    //
+    //   export-environment-variables: |
+    //     JIRA_API_TOKEN
+    //     JIRA_CLOUD_ID
+    //     JIRA_WORKSPACE_ID
+    //     SCRIPT_DIRECTORY_PATH
+    //
+    // must produce four independent identity mappings, not a single bogus
+    // entry containing embedded newlines.
+    const input = 'JIRA_API_TOKEN\nJIRA_CLOUD_ID\nJIRA_WORKSPACE_ID\nSCRIPT_DIRECTORY_PATH';
+    const [mappings, all] = parseExportMappings(input);
+    assert.deepEqual(mappings, {
+        JIRA_API_TOKEN: 'JIRA_API_TOKEN',
+        JIRA_CLOUD_ID: 'JIRA_CLOUD_ID',
+        JIRA_WORKSPACE_ID: 'JIRA_WORKSPACE_ID',
+        SCRIPT_DIRECTORY_PATH: 'SCRIPT_DIRECTORY_PATH',
+    });
+    assert.equal(all, false);
+});
+
+test('parseExportMappings supports a mix of commas and newlines', () => {
+    const input = 'FOO=BAR,\nBAZ\nQUX=QUUX,\n*';
+    const [mappings, all] = parseExportMappings(input);
+    assert.deepEqual(mappings, {
+        FOO: 'BAR',
+        BAZ: 'BAZ',
+        QUX: 'QUUX',
+    });
+    assert.equal(all, true);
+});
+
+test('parseExportMappings trims whitespace around entries and trailing newlines', () => {
+    const input = '  FOO=BAR  \n  BAZ  \n';
+    const [mappings] = parseExportMappings(input);
+    assert.deepEqual(mappings, { FOO: 'BAR', BAZ: 'BAZ' });
+});
+
+test('parseExportMappings treats a bare * as a wildcard, not a mapping', () => {
+    const [mappings, all] = parseExportMappings('*');
+    assert.deepEqual(mappings, {});
+    assert.equal(all, true);
+});

--- a/src/parse-mapping.ts
+++ b/src/parse-mapping.ts
@@ -1,0 +1,62 @@
+// Parse the `keys` and `export-environment-variables` action inputs.
+//
+// Both inputs accept a list of entries. Historically entries could only be
+// separated by commas (`FOO,BAR,BAZ`), but GitHub Actions YAML also commonly
+// supplies list-like values as a block scalar, one entry per line:
+//
+//   export-environment-variables: |
+//     JIRA_API_TOKEN
+//     JIRA_CLOUD_ID
+//     JIRA_WORKSPACE_ID
+//
+// If entries are only split on `,`, a newline-separated block collapses into
+// a single bogus entry containing embedded newlines (since there's no comma
+// to split on), which then fails to match any real key in the opened
+// environment. To support both styles -- and any mix of the two -- entries
+// are split on commas and/or newlines, with surrounding whitespace trimmed
+// and empty entries discarded.
+const SEPARATOR = /[,\n]/;
+
+function splitEntries(input: string): string[] {
+    return input
+        .split(SEPARATOR)
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0);
+}
+
+// Parses the deprecated `keys` input: a list of key names to inject as-is.
+export function parseKeysList(keys: string): string[] {
+    return splitEntries(keys);
+}
+
+// Parses the `export-environment-variables` input (once it's been
+// determined not to be a boolean) into a mapping of destination envvar name
+// to source ESC environment variable name, plus whether unmapped variables
+// should also be exported (triggered by a bare `*` entry).
+//
+// Each entry takes one of the following three forms:
+//
+// 1. `FOO=BAR`, which maps the ESC secret named `BAR` to the environment
+//    variable `FOO`
+// 2. `BAR`, which maps the ESC secret named `BAR` to the environment
+//    variable `BAR` (equivalent to `BAR=BAR`)
+// 3. `*`, which adds identity mappings for any unmapped secrets
+export function parseExportMappings(input: string): [Record<string, string>, boolean] {
+    let all = false;
+    const mappings: Record<string, string> = {};
+    for (const entry of splitEntries(input)) {
+        if (entry === '*') {
+            all = true;
+            continue;
+        }
+
+        const eq = entry.indexOf('=');
+        if (eq === -1) {
+            mappings[entry] = entry;
+        } else {
+            const [to, from] = [entry.slice(0, eq), entry.slice(eq + 1)];
+            mappings[to] = from;
+        }
+    }
+    return [mappings, all];
+}


### PR DESCRIPTION
## Problem

The `export-environment-variables` (and deprecated `keys`) inputs were only split on commas:

```ts
for (const mapping of input.split(',').map(v => v.trim())) {
```

GitHub Actions workflows commonly supply list-like inputs as a YAML block scalar, one entry per line:

```yaml
export-environment-variables: |
  JIRA_API_TOKEN
  JIRA_CLOUD_ID
  JIRA_WORKSPACE_ID
  SCRIPT_DIRECTORY_PATH
```

YAML joins block scalar lines with `\n`, not `,`. Since there's no comma in the string, `input.split(',')` returns a single element — the entire multi-line blob. That blob has no `=` in it, so it falls into the "identity mapping" branch and produces one mapping whose key *and* value are both the same multi-line string. The result is every requested variable silently fails to export, with a warning like:

```
No value found for JIRA_API_TOKEN
JIRA_CLOUD_ID
JIRA_WORKSPACE_ID
SCRIPT_DIRECTORY_PATH=environmentVariables.JIRA_API_TOKEN
JIRA_CLOUD_ID
JIRA_WORKSPACE_ID
SCRIPT_DIRECTORY_PATH
```

This looks like a permissions or import-chain problem (opening the environment succeeds and `environmentVariables`/`files` step outputs are populated correctly — it's only the `export-environment-variables`/`keys` mapping step that's affected), which makes it a confusing failure mode to debug.

## Fix

- Extracted the mapping/keys parsing logic into a new `src/parse-mapping.ts` (`parseKeysList`, `parseExportMappings`).
- Entries are now split on `/[,\n]/` (commas and/or newlines), with whitespace trimmed and empty entries discarded.
- Comma-separated single-line lists continue to work exactly as before — this purely adds newline as an additional accepted separator, so it's fully backward compatible.
- Added `src/parse-mapping.test.ts` with unit tests covering: comma-only lists, newline-only lists (the regression case), mixed comma/newline lists, whitespace trimming, and the `*` wildcard.
- Updated `README.md` to document that mappings may be separated by commas, newlines, or both, with an example using a YAML block scalar.
- Rebuilt `dist/index.js`.

## Testing

```
npm test    # 22/22 passing
npm run build
```


Fixes #53

---
*Created with [Eon](https://eon.corp.pulumi.com/session/d8716fcb10c995639fc2e06a0ecc51d7)*