### PR TITLE
Prepare v3.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esc-action",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## What

Bumps `package.json` version `3.0.0` → `3.1.0` ahead of tagging the `v3.1.0` release.

This is the "prepare release" PR (same pattern as #46 for v2.0.0). No README changes are needed — the usage examples pin to the moving major tag `@v3`, which is unchanged by a minor release.

## Changes included in v3.1.0 (all backward-compatible)

Everything on `main` since the `v3.0.0` tag:

- #48 — Use `pulumi env` instead of the `pulumi esc` alias
- #49 — fix: use tool-cache extraction directory
- #51 — Mark `dist/` as generated for GitHub linguist
- #52 — fix: allow newline-separated entries in `export-environment-variables`/`keys`

Minor bump (not patch) because #52 adds a new accepted input format (newline-separated lists) — new backward-compatible functionality.

## Release steps after merge

1. Tag `v3.1.0` on `main` and push
2. `gh release create v3.1.0 --generate-notes`
3. Advance the moving major tag: `git tag -f v3 v3.1.0 && git push origin v3 --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)