### PR TITLE
Prepare v3.2.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esc-action",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## What

Bumps `package.json` version `3.1.0` → `3.2.0` ahead of tagging the `v3.2.0` release.

This is the "prepare release" PR (same pattern as #54 for v3.1.0). No README changes are needed — the usage examples pin to the moving major tag `@v3`, which is unchanged by a minor release.

## Changes included in v3.2.0

Everything on `main` since the `v3.1.0` tag:

- #55 — Mask only secrets by opening ESC environments with `--format detailed`

⚠️ **Behavior change worth calling out:** previously *every* value pulled from an environment was passed to `core.setSecret()` and masked in logs. As of #55, only values marked secret in the ESC environment are masked; non-secret values are now readable in workflow logs. Pulumi CLI versions older than v3.255.0 fall back to the old dotenv path and keep masking everything.

Minor bump (not major) because inputs, outputs, and the action's API are unchanged.

## Release steps after merge

1. Tag `v3.2.0` on `main` and push
2. `gh release create v3.2.0 --generate-notes`
3. Advance the moving major tag: `git tag -f v3 v3.2.0 && git push origin v3 --force`