### PR TITLE
Report the URL and underlying cause when the latest-version lookup fails

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52400,6 +52400,31 @@ function parseDotenv(stdout) {
     return dotenv;
 }
 
+// Resolve the Pulumi CLI version to install when the caller did not pin one.
+const LATEST_VERSION_URL = 'https://www.pulumi.com/latest-version';
+// `fetch` rejects with a bare `TypeError: fetch failed` and hides the real
+// reason (ENOTFOUND, ECONNRESET, certificate errors, ...) on `cause`. Unfold it
+// so the failure names something the user can act on.
+function describeError(err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const cause = err?.cause;
+    return cause instanceof Error ? `${message}: ${cause.message}` : message;
+}
+async function fetchLatestVersion() {
+    let response;
+    try {
+        response = await fetch(LATEST_VERSION_URL);
+    }
+    catch (err) {
+        throw new Error(`failed to fetch the latest Pulumi CLI version from ${LATEST_VERSION_URL}: ${describeError(err)}`, { cause: err });
+    }
+    if (!response.ok) {
+        throw new Error(`failed to fetch the latest Pulumi CLI version from ${LATEST_VERSION_URL}: ` +
+            `HTTP ${response.status} ${response.statusText}`.trimEnd());
+    }
+    return (await response.text()).trim();
+}
+
 // Parse the `keys` and `export-environment-variables` action inputs.
 //
 // Both inputs accept a list of entries. Historically entries could only be
@@ -52637,7 +52662,7 @@ async function run() {
             },
         });
         // Parse inputs
-        const pulumiVersion = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/latest-version').then(r => r.text()).then(t => t.trim());
+        const pulumiVersion = getInput('version', 'VERSION') || await fetchLatestVersion();
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import * as axiosRetryModule from 'axios-retry';
 import axios from 'axios';
 import { parseDetailedEnvironmentVariables, type DetailedEnvironment } from './parse-detailed.js';
 import { parseDotenv } from './parse-dotenv.js';
+import { fetchLatestVersion } from './latest-version.js';
 import { parseKeysList, parseExportMappings } from './parse-mapping.js';
 
 // axios-retry v4 exports as CJS, need to access default export
@@ -237,7 +238,7 @@ async function run(): Promise<void> {
         });
 
         // Parse inputs
-        const pulumiVersion: string = getInput('version', 'VERSION') || await fetch('https://www.pulumi.com/latest-version').then(r => r.text()).then(t => t.trim());
+        const pulumiVersion: string = getInput('version', 'VERSION') || await fetchLatestVersion();
         const environment = getInput('environment', 'ENVIRONMENT');
         const keys = getInput('keys', 'KEYS');
         const cloudUrl = getInput('cloud-url', 'CLOUD_URL') || 'https://api.pulumi.com';

--- a/src/latest-version.test.ts
+++ b/src/latest-version.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { fetchLatestVersion, LATEST_VERSION_URL } from './latest-version.js';
+
+const urlPattern = new RegExp(LATEST_VERSION_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+
+// Swap in a stub `fetch` for the duration of one test.
+function withFetch(stub: typeof fetch, body: () => Promise<void>): Promise<void> {
+    const original = globalThis.fetch;
+    globalThis.fetch = stub;
+    return body().finally(() => {
+        globalThis.fetch = original;
+    });
+}
+
+// The shape undici throws when the request never reaches the server: a
+// TypeError whose message is the bare string 'fetch failed', with the real
+// reason hidden on `cause`.
+function fetchFailed(): TypeError {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = Object.assign(
+        new Error('getaddrinfo ENOTFOUND www.pulumi.com'),
+        { code: 'ENOTFOUND' },
+    );
+    return err;
+}
+
+test('returns the trimmed latest version', async () => {
+    await withFetch(
+        (async () => new Response('3.255.0\n')) as typeof fetch,
+        async () => {
+            assert.equal(await fetchLatestVersion(), '3.255.0');
+        },
+    );
+});
+
+test('names the URL and the underlying cause when the lookup fails', async () => {
+    await withFetch(
+        (async () => {
+            throw fetchFailed();
+        }) as typeof fetch,
+        async () => {
+            await assert.rejects(fetchLatestVersion(), (err: Error) => {
+                assert.notEqual(
+                    err.message,
+                    'fetch failed',
+                    'a bare "fetch failed" tells the user nothing about what was being fetched',
+                );
+                assert.match(err.message, urlPattern);
+                assert.match(err.message, /ENOTFOUND/);
+                return true;
+            });
+        },
+    );
+});
+
+test('rejects an error response instead of treating the error page as a version', async () => {
+    await withFetch(
+        (async () => new Response('<html>502 Bad Gateway</html>', { status: 502, statusText: 'Bad Gateway' })) as typeof fetch,
+        async () => {
+            await assert.rejects(fetchLatestVersion(), (err: Error) => {
+                assert.match(err.message, urlPattern);
+                assert.match(err.message, /502/);
+                return true;
+            });
+        },
+    );
+});

--- a/src/latest-version.ts
+++ b/src/latest-version.ts
@@ -1,0 +1,32 @@
+// Resolve the Pulumi CLI version to install when the caller did not pin one.
+export const LATEST_VERSION_URL = 'https://www.pulumi.com/latest-version';
+
+// `fetch` rejects with a bare `TypeError: fetch failed` and hides the real
+// reason (ENOTFOUND, ECONNRESET, certificate errors, ...) on `cause`. Unfold it
+// so the failure names something the user can act on.
+function describeError(err: unknown): string {
+    const message = err instanceof Error ? err.message : String(err);
+    const cause = (err as { cause?: unknown })?.cause;
+    return cause instanceof Error ? `${message}: ${cause.message}` : message;
+}
+
+export async function fetchLatestVersion(): Promise<string> {
+    let response: Response;
+    try {
+        response = await fetch(LATEST_VERSION_URL);
+    } catch (err) {
+        throw new Error(
+            `failed to fetch the latest Pulumi CLI version from ${LATEST_VERSION_URL}: ${describeError(err)}`,
+            { cause: err },
+        );
+    }
+
+    if (!response.ok) {
+        throw new Error(
+            `failed to fetch the latest Pulumi CLI version from ${LATEST_VERSION_URL}: ` +
+            `HTTP ${response.status} ${response.statusText}`.trimEnd(),
+        );
+    }
+
+    return (await response.text()).trim();
+}


### PR DESCRIPTION
When no `version` input is pinned, the action resolves the latest Pulumi CLI version with `fetch`. undici rejects with a bare `TypeError: fetch failed` and keeps the real reason on `cause`, so the step failed with nothing but `::error::fetch failed`. The lookup now names the URL and unfolds the cause, and rejects a non-2xx response rather than passing an error page along as a version string.

Before: `::error::fetch failed`
After: `::error::failed to fetch the latest Pulumi CLI version from https://www.pulumi.com/latest-version: fetch failed: getaddrinfo ENOTFOUND www.pulumi.com`

Part of #57
